### PR TITLE
fix(MOD): Disable sending flight trainer mails at level 60

### DIFF
--- a/src/Bracket_60_1/sql/world/progression_60_1_mail_level_rewards.sql
+++ b/src/Bracket_60_1/sql/world/progression_60_1_mail_level_rewards.sql
@@ -1,0 +1,2 @@
+-- Disable flight trainer mails
+DELETE FROM `mail_level_reward` WHERE `level` = 60 AND `senderEntry` IN (35093, 35100);

--- a/src/Bracket_71_74/sql/world/progression_71_74_npc_vendor - kopia.sql
+++ b/src/Bracket_71_74/sql/world/progression_71_74_npc_vendor - kopia.sql
@@ -1,0 +1,5 @@
+-- Reenable flight trainer mails
+DELETE FROM `mail_level_reward` WHERE `level` = 60 AND `senderEntry` IN (35093, 35100);
+INSERT INTO `mail_level_reward` (`level`, `raceMask`, `mailTemplateId`, `senderEntry`) VALUES
+(60,690,282,35093),
+(60,1101,283,35100);


### PR DESCRIPTION
Disables sending flight master notices to level 60 characters.
SQL content tested.
**SQL automatic loading not tested.**
**SQL automatic loading/Reenabling it during the level 71 bracket not tested. (should it be enable in that bracket?)**

Closes https://github.com/azerothcore/mod-progression-system/issues/75