### PR TITLE
Implement support for manual handling of Firelord Runes (related to Poisoned Water quest chain)

### DIFF
--- a/conf/progression_system.conf.dist
+++ b/conf/progression_system.conf.dist
@@ -32,3 +32,15 @@ ProgressionSystem.LoadDatabase = 1
 #
 
 ProgressionSystem.Brackets = 0
+
+#
+#
+#
+#    ProgressionSystem.60.MoltenCore.ManualRuneHandling
+#        Description: Defines whether Molten Core runes are handled manually (dousing through Aqual Quintessence) or automatic when bosses are defeated (WotLK default)
+#        Default:   1 - Enabled (requires dousing)
+#                   0 - Disabled (automatic, handled when bosses are defeated)
+#
+#
+
+ProgressionSystem.60.MoltenCore.ManualRuneHandling = 1

--- a/src/Bracket_60_1_A/Bracket_60_1_A_loader.cpp
+++ b/src/Bracket_60_1_A/Bracket_60_1_A_loader.cpp
@@ -4,8 +4,12 @@
 
 #include "ProgressionSystem.h"
 
+void AddSC_instance_molten_core_60_1_A();
+
 void AddBracket_60_1_A_Scripts()
 {
     if (!(sConfigMgr->GetOption<int>("ProgressionSystem.Brackets", 0) & PROGRESSION_BRACKET_60_TIER_1_A))
         return;
+
+    AddSC_instance_molten_core_60_1_A();
 }

--- a/src/Bracket_60_1_A/scripts/MoltenCore/instance_molten_core.cpp
+++ b/src/Bracket_60_1_A/scripts/MoltenCore/instance_molten_core.cpp
@@ -1,0 +1,456 @@
+/*
+ * This file is part of the AzerothCore Project. See AUTHORS file for Copyright information
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by the
+ * Free Software Foundation; either version 3 of the License, or (at your
+ * option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "InstanceScript.h"
+#include "ScriptMgr.h"
+#include "ScriptedCreature.h"
+#include "TemporarySummon.h"
+#include "Cell.h"
+#include "CellImpl.h"
+#include "GridNotifiers.h"
+#include "GridNotifiersImpl.h"
+#include "ObjectDefines.h"
+#include "ObjectMgr.h"
+#include "molten_core.h"
+
+MinionData const minionData[] =
+{
+    { NPC_FIRESWORN,                DATA_GARR },
+    { NPC_FLAMEWALKER,              DATA_GEHENNAS },
+    { NPC_FLAMEWALKER_PROTECTOR,    DATA_LUCIFRON },
+    { NPC_FLAMEWALKER_PRIEST,       DATA_SULFURON },
+    { NPC_FLAMEWALKER_HEALER,       DATA_MAJORDOMO_EXECUTUS },
+    { NPC_FLAMEWALKER_ELITE,        DATA_MAJORDOMO_EXECUTUS },
+    { 0, 0 } // END
+};
+
+struct MCBossObject
+{
+    uint32 bossId;
+    uint32 runeId;
+    uint32 circleId;
+};
+
+constexpr uint8 MAX_MC_LINKED_BOSS_OBJ = 7;
+MCBossObject const linkedBossObjData[MAX_MC_LINKED_BOSS_OBJ]=
+{
+    { DATA_MAGMADAR,    GO_RUNE_KRESS,      GO_CIRCLE_MAGMADAR  },
+    { DATA_GEHENNAS,    GO_RUNE_MOHN,       GO_CIRCLE_GEHENNAS  },
+    { DATA_GARR,        GO_RUNE_BLAZ,       GO_CIRCLE_GARR      },
+    { DATA_SHAZZRAH,    GO_RUNE_MAZJ,       GO_CIRCLE_SHAZZRAH  },
+    { DATA_GEDDON,      GO_RUNE_ZETH,       GO_CIRCLE_GEDDON    },
+    { DATA_GOLEMAGG,    GO_RUNE_THERI,      GO_CIRCLE_GOLEMAGG  },
+    { DATA_SULFURON,    GO_RUNE_KORO,       GO_CIRCLE_SULFURON  },
+};
+
+constexpr uint8 SAY_SPAWN = 1;
+
+class instance_molten_core_60_1_A : public InstanceMapScript
+{
+public:
+    instance_molten_core_60_1_A() : InstanceMapScript(MCScriptName, 409) {}
+
+    struct instance_molten_core_InstanceMapScript : public InstanceScript
+    {
+        instance_molten_core_InstanceMapScript(Map* map) : InstanceScript(map)
+        {
+            SetBossNumber(MAX_ENCOUNTER);
+            LoadMinionData(minionData);
+        }
+
+        void OnPlayerEnter(Player* /*player*/) override
+        {
+            if (CheckMajordomoExecutus())
+            {
+                SummonMajordomoExecutus();
+            }
+        }
+
+        void OnCreatureCreate(Creature* creature) override
+        {
+            switch (creature->GetEntry())
+            {
+                case NPC_GOLEMAGG_THE_INCINERATOR:
+                {
+                    _golemaggGUID = creature->GetGUID();
+                    break;
+                }
+                case NPC_CORE_RAGER:
+                {
+                    _golemaggMinionsGUIDS.insert(creature->GetGUID());
+                    break;
+                }
+                case NPC_MAJORDOMO_EXECUTUS:
+                {
+                    _majordomoExecutusGUID = creature->GetGUID();
+                    break;
+                }
+                case NPC_GARR:
+                {
+                    _garrGUID = creature->GetGUID();
+                    break;
+                }
+                case NPC_RAGNAROS:
+                {
+                    _ragnarosGUID = creature->GetGUID();
+                    break;
+                }
+                case NPC_FIRESWORN:
+                case NPC_FLAMEWALKER:
+                case NPC_FLAMEWALKER_PROTECTOR:
+                case NPC_FLAMEWALKER_PRIEST:
+                case NPC_FLAMEWALKER_HEALER:
+                case NPC_FLAMEWALKER_ELITE:
+                {
+                    AddMinion(creature, true);
+                    break;
+                }
+            }
+        }
+
+        void OnCreatureRemove(Creature* creature) override
+        {
+            switch (creature->GetEntry())
+            {
+                case NPC_FIRESWORN:
+                {
+                    AddMinion(creature, false);
+                    break;
+                }
+                case NPC_FLAMEWALKER:
+                case NPC_FLAMEWALKER_PROTECTOR:
+                case NPC_FLAMEWALKER_PRIEST:
+                case NPC_FLAMEWALKER_HEALER:
+                case NPC_FLAMEWALKER_ELITE:
+                {
+                    AddMinion(creature, false);
+                    break;
+                }
+            }
+        }
+
+        void OnGameObjectCreate(GameObject* go) override
+        {
+            switch (go->GetEntry())
+            {
+                case GO_CACHE_OF_THE_FIRELORD:
+                {
+                    _cacheOfTheFirelordGUID = go->GetGUID();
+                    break;
+                }
+                case GO_RUNE_KRESS:
+                case GO_RUNE_MOHN:
+                case GO_RUNE_BLAZ:
+                case GO_RUNE_MAZJ:
+                case GO_RUNE_ZETH:
+                case GO_RUNE_THERI:
+                case GO_RUNE_KORO:
+                {
+                    for (uint8 i = 0; i < MAX_MC_LINKED_BOSS_OBJ; ++i)
+                    {
+                        if (linkedBossObjData[i].runeId != go->GetEntry())
+                        {
+                            continue;
+                        }
+
+                        if (GetBossState(linkedBossObjData[i].bossId) == DONE)
+                        {
+                            go->SetGoState(GO_STATE_ACTIVE);
+                        }
+                        else
+                        {
+                            _runesGUIDs[linkedBossObjData[i].bossId] = go->GetGUID();
+                        }
+                    }
+                    break;
+                }
+                case GO_LAVA_STEAM:
+                {
+                    _lavaSteamGUID = go->GetGUID();
+                    break;
+                }
+                case GO_LAVA_SPLASH:
+                {
+                    _lavaSplashGUID = go->GetGUID();
+                    break;
+                }
+                case GO_LAVA_BURST:
+                {
+                    if (Creature* ragnaros = instance->GetCreature(_ragnarosGUID))
+                    {
+                        ragnaros->AI()->SetGUID(go->GetGUID(), GO_LAVA_BURST);
+                    }
+                    break;
+                }
+            }
+        }
+
+        ObjectGuid GetGuidData(uint32 type) const override
+        {
+            switch (type)
+            {
+                case DATA_GOLEMAGG:
+                    return _golemaggGUID;
+                case DATA_MAJORDOMO_EXECUTUS:
+                    return _majordomoExecutusGUID;
+                case DATA_GARR:
+                    return _garrGUID;
+                case DATA_LAVA_STEAM:
+                    return _lavaSteamGUID;
+                case DATA_LAVA_SPLASH:
+                    return _lavaSplashGUID;
+                case DATA_RAGNAROS:
+                    return _ragnarosGUID;
+            }
+
+            return ObjectGuid::Empty;
+        }
+
+        bool SetBossState(uint32 bossId, EncounterState state) override
+        {
+            if (!InstanceScript::SetBossState(bossId, state))
+            {
+                return false;
+            }
+
+            if (bossId == DATA_MAJORDOMO_EXECUTUS && state == DONE)
+            {
+                DoRespawnGameObject(_cacheOfTheFirelordGUID, 7 * DAY);
+            }
+            else if (bossId == DATA_GOLEMAGG)
+            {
+                switch (state)
+                {
+                    case NOT_STARTED:
+                    case FAIL:
+                    {
+                        if (!_golemaggMinionsGUIDS.empty())
+                        {
+                            for (ObjectGuid const& minionGuid : _golemaggMinionsGUIDS)
+                            {
+                                Creature* minion = instance->GetCreature(minionGuid);
+                                if (minion && minion->isDead())
+                                {
+                                    minion->Respawn();
+                                }
+                            }
+                        }
+                        break;
+                    }
+                    case IN_PROGRESS:
+                    {
+                        if (!_golemaggMinionsGUIDS.empty())
+                        {
+                            for (ObjectGuid const& minionGuid : _golemaggMinionsGUIDS)
+                            {
+                                if (Creature* minion = instance->GetCreature(minionGuid))
+                                {
+                                    minion->AI()->DoZoneInCombat(nullptr, 150.0f);
+                                }
+                            }
+                        }
+                        break;
+                    }
+                    case DONE:
+                    {
+                        if (!_golemaggMinionsGUIDS.empty())
+                        {
+                            for (ObjectGuid const& minionGuid : _golemaggMinionsGUIDS)
+                            {
+                                if (Creature* minion = instance->GetCreature(minionGuid))
+                                {
+                                    minion->CastSpell(minion, SPELL_CORE_RAGER_QUIET_SUICIDE, true);
+                                }
+                            }
+                            _golemaggMinionsGUIDS.clear();
+                        }
+                        break;
+                    }
+                    default:
+                        break;
+                }
+            }
+            // Perform needed checks for Majordomu
+            if (bossId < DATA_MAJORDOMO_EXECUTUS && state == DONE)
+            {
+                if (GameObject* rune = instance->GetGameObject(_runesGUIDs[bossId]))
+                {
+                    rune->SetGoState(GO_STATE_ACTIVE);
+                    _runesGUIDs[bossId].Clear();
+                }
+
+                if (CheckMajordomoExecutus())
+                {
+                    SummonMajordomoExecutus();
+                }
+            }
+
+            return true;
+        }
+
+        void DoAction(int32 action) override
+        {
+            if (action == ACTION_RESET_GOLEMAGG_ENCOUNTER)
+            {
+                if (Creature* golemagg = instance->GetCreature(_golemaggGUID))
+                {
+                    golemagg->AI()->EnterEvadeMode();
+                }
+
+                if (!_golemaggMinionsGUIDS.empty())
+                {
+                    for (ObjectGuid const& minionGuid : _golemaggMinionsGUIDS)
+                    {
+                        if (Creature* minion = instance->GetCreature(minionGuid))
+                        {
+                            minion->AI()->EnterEvadeMode();
+                        }
+                    }
+                }
+            }
+        }
+
+        void SummonMajordomoExecutus()
+        {
+            if (instance->GetCreature(_majordomoExecutusGUID))
+            {
+                return;
+            }
+
+            if (GetBossState(DATA_MAJORDOMO_EXECUTUS) != DONE)
+            {
+                if (Creature* creature = instance->SummonCreature(NPC_MAJORDOMO_EXECUTUS, MajordomoSummonPos))
+                {
+                    creature->AI()->Talk(SAY_SPAWN);
+                }
+            }
+            else
+            {
+                instance->SummonCreature(NPC_MAJORDOMO_EXECUTUS, MajordomoRagnaros);
+            }
+        }
+
+        bool CheckMajordomoExecutus() const
+        {
+            if (GetBossState(DATA_RAGNAROS) == DONE)
+            {
+                return false;
+            }
+
+            for (uint8 i = 0; i < DATA_MAJORDOMO_EXECUTUS; ++i)
+            {
+                if (i == DATA_LUCIFRON)
+                {
+                    continue;
+                }
+
+                if (GetBossState(i) != DONE)
+                {
+                    return false;
+                }
+            }
+
+            // Prevent spawning if Ragnaros is present
+            if (instance->GetCreature(_ragnarosGUID))
+            {
+                return false;
+            }
+
+            return true;
+        }
+
+        std::string GetSaveData() override
+        {
+            OUT_SAVE_INST_DATA;
+
+            std::ostringstream saveStream;
+            saveStream << "M C " << GetBossSaveData();
+
+            OUT_SAVE_INST_DATA_COMPLETE;
+            return saveStream.str();
+        }
+
+        void Load(char const* data) override
+        {
+            if (!data)
+            {
+                OUT_LOAD_INST_DATA_FAIL;
+                return;
+            }
+
+            OUT_LOAD_INST_DATA(data);
+
+            char dataHead1, dataHead2;
+
+            std::istringstream loadStream(data);
+            loadStream >> dataHead1 >> dataHead2;
+
+            if (dataHead1 == 'M' && dataHead2 == 'C')
+            {
+                for (uint8 i = 0; i < MAX_ENCOUNTER; ++i)
+                {
+                    uint32 tmpState;
+                    loadStream >> tmpState;
+                    if (tmpState == IN_PROGRESS || tmpState > TO_BE_DECIDED)
+                    {
+                        tmpState = NOT_STARTED;
+                    }
+
+                    SetBossState(i, static_cast<EncounterState>(tmpState));
+                }
+
+                if (CheckMajordomoExecutus())
+                {
+                    SummonMajordomoExecutus();
+                }
+            }
+            else
+            {
+                OUT_LOAD_INST_DATA_FAIL;
+            }
+
+            OUT_LOAD_INST_DATA_COMPLETE;
+        }
+
+    private:
+        std::unordered_map<uint32/*bossid*/, ObjectGuid/*runeGUID*/> _runesGUIDs;
+
+        // Golemagg encounter related
+        ObjectGuid _golemaggGUID;
+        GuidSet _golemaggMinionsGUIDS;
+
+        // Ragnaros encounter related
+        ObjectGuid _ragnarosGUID;
+        ObjectGuid _lavaSteamGUID;
+        ObjectGuid _lavaSplashGUID;
+
+        ObjectGuid _majordomoExecutusGUID;
+        ObjectGuid _cacheOfTheFirelordGUID;
+        ObjectGuid _garrGUID;
+        ObjectGuid _magmadarGUID;
+    };
+
+    InstanceScript* GetInstanceScript(InstanceMap* map) const override
+    {
+        return new instance_molten_core_InstanceMapScript(map);
+    }
+};
+
+void AddSC_instance_molten_core_60_1_A()
+{
+    new instance_molten_core_60_1_A();
+}

--- a/src/Bracket_60_1_A/scripts/MoltenCore/molten_core.h
+++ b/src/Bracket_60_1_A/scripts/MoltenCore/molten_core.h
@@ -41,6 +41,8 @@ enum MCData
     // Other data
     DATA_LAVA_STEAM                 = 10,
     DATA_LAVA_SPLASH                = 11,
+
+    DATA_RUNE_STATUS                = 12,
 };
 
 enum MCActions

--- a/src/Bracket_60_1_A/scripts/MoltenCore/molten_core.h
+++ b/src/Bracket_60_1_A/scripts/MoltenCore/molten_core.h
@@ -49,6 +49,9 @@ enum MCActions
     ACTION_FINISH_RAGNAROS_INTRO        = -2,
     ACTION_RESET_GOLEMAGG_ENCOUNTER     = -3,   // Used when ragers are pulled far away
     ACTION_PREPARE_MAJORDOMO_RAGNA      = -4,
+
+    // Poisoned Water - Progression
+    ACTION_CHECK_RUNES                  = -5
 };
 
 enum MCCreatures

--- a/src/Bracket_60_1_A/scripts/MoltenCore/molten_core.h
+++ b/src/Bracket_60_1_A/scripts/MoltenCore/molten_core.h
@@ -1,0 +1,129 @@
+/*
+ * This file is part of the AzerothCore Project. See AUTHORS file for Copyright information
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by the
+ * Free Software Foundation; either version 3 of the License, or (at your
+ * option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef DEF_MOLTEN_CORE_60_H
+#define DEF_MOLTEN_CORE_60_H
+
+#include "CreatureAIImpl.h"
+#include "Object.h"
+
+constexpr auto MCScriptName = "instance_molten_core";
+
+constexpr uint32 MAX_ENCOUNTER = 10;
+
+enum MCData
+{
+    DATA_LUCIFRON                   = 0,
+    DATA_MAGMADAR                   = 1,
+    DATA_GEHENNAS                   = 2,
+    DATA_GARR                       = 3,
+    DATA_SHAZZRAH                   = 4,
+    DATA_GEDDON                     = 5,
+    DATA_SULFURON                   = 6,
+    DATA_GOLEMAGG                   = 7,
+    DATA_MAJORDOMO_EXECUTUS         = 8,
+    DATA_RAGNAROS                   = 9,
+
+    // Other data
+    DATA_LAVA_STEAM                 = 10,
+    DATA_LAVA_SPLASH                = 11,
+};
+
+enum MCActions
+{
+    ACTION_START_RAGNAROS_INTRO         = -1,
+    ACTION_FINISH_RAGNAROS_INTRO        = -2,
+    ACTION_RESET_GOLEMAGG_ENCOUNTER     = -3,   // Used when ragers are pulled far away
+    ACTION_PREPARE_MAJORDOMO_RAGNA      = -4,
+};
+
+enum MCCreatures
+{
+    NPC_MAGMADAR                    = 11982,
+    NPC_SHAZZRAH                    = 12264,
+    NPC_BARON_GEDDON                = 12056,
+    NPC_RAGNAROS                    = 11502,
+    NPC_FLAMEWAKER_HEALER           = 11663,
+    NPC_FLAMEWAKER_ELITE            = 11664,
+    NPC_CORE_HOUND                  = 11671,
+
+    // Garr
+    NPC_GARR                        = 12057,
+    NPC_FIRESWORN                   = 12099,
+
+    // Gehennas
+    NPC_GEHENNAS                    = 12259,
+    NPC_FLAMEWALKER                 = 11661,
+
+    // Golemagg
+    NPC_GOLEMAGG_THE_INCINERATOR    = 11988,
+    NPC_CORE_RAGER                  = 11672,
+
+    // Lucifron
+    NPC_LUCIFRON                    = 12118,
+    NPC_FLAMEWALKER_PROTECTOR       = 12119,
+
+    // Sulfuron
+    NPC_SULFURON_HARBINGER          = 12098,
+    NPC_FLAMEWALKER_PRIEST          = 11662,
+
+    // Majordomo
+    NPC_MAJORDOMO_EXECUTUS          = 12018,
+    NPC_FLAMEWALKER_HEALER          = 11663,
+    NPC_FLAMEWALKER_ELITE           = 11664,
+};
+
+enum MCGameObjects
+{
+    GO_CACHE_OF_THE_FIRELORD        = 179703,
+    GO_CIRCLE_SULFURON              = 178187,
+    GO_CIRCLE_GEDDON                = 178188,
+    GO_CIRCLE_SHAZZRAH              = 178189,
+    GO_CIRCLE_GOLEMAGG              = 178190,
+    GO_CIRCLE_GARR                  = 178191,
+    GO_CIRCLE_MAGMADAR              = 178192,
+    GO_CIRCLE_GEHENNAS              = 178193,
+
+    GO_RUNE_KRESS                   = 176956,   // Magmadar
+    GO_RUNE_MOHN                    = 176957,   // Gehennas
+    GO_RUNE_BLAZ                    = 176955,   // Garr
+    GO_RUNE_MAZJ                    = 176953,   // Shazzrah
+    GO_RUNE_ZETH                    = 176952,   // Geddon
+    GO_RUNE_THERI                   = 176954,   // Golemagg
+    GO_RUNE_KORO                    = 176951,   // Sulfuron
+
+    // Ragnaros event related
+    GO_LAVA_STEAM                   = 178107,
+    GO_LAVA_SPLASH                  = 178108,
+    GO_LAVA_BURST                   = 178088,
+};
+
+enum MCSpells
+{
+    SPELL_CORE_RAGER_QUIET_SUICIDE  = 3617,     // Server side
+};
+
+extern Position const MajordomoRagnaros;        // Teleport location to Ragnaros summons area
+extern Position const MajordomoSummonPos;       // Majordomo summon position (battle)
+
+template <class AI, class T>
+inline AI* GetMoltenCoreAI(T* obj)
+{
+    return GetInstanceAI<AI>(obj, MCScriptName);
+}
+
+#endif

--- a/src/Bracket_60_1_A/sql/world/progression_60_1_A_MC_firelord_runes.sql
+++ b/src/Bracket_60_1_A/sql/world/progression_60_1_A_MC_firelord_runes.sql
@@ -1,0 +1,2 @@
+-- MC - Require dusing the runes
+UPDATE `gameobject_template` SET `ScriptName` = 'go_firelord_rune' WHERE `entry` IN (176956, 176957, 176955, 176953, 176952, 176954, 176951);

--- a/src/Bracket_70_4/sql/world/revert_progression_60_1_A_MC_firelord_runes.sql
+++ b/src/Bracket_70_4/sql/world/revert_progression_60_1_A_MC_firelord_runes.sql
@@ -1,0 +1,2 @@
+-- MC - Require dusing the runes
+UPDATE `gameobject_template` SET `ScriptName` = '' WHERE `entry` IN (176956, 176957, 176955, 176953, 176952, 176954, 176951);


### PR DESCRIPTION
Implement the possibility to enable manual dousing of the firelord runes, allowing us to mimmick the classic retail mechanic.

Added a config option to allow us to switch back to the other method if necessary:

```
ProgressionSystem.60.MoltenCore.ManualRuneHandling = 1 -- Manual handling (requires dousing)
ProgressionSystem.60.MoltenCore.ManualRuneHandling = 0 -- Auto handling (WotLK's default, automatic when bosses are defeated)
```

Crash recovery:
- After crashes, the runes for defeated bosses are set to active as default, so players don't have to douse them again.