### PR TITLE
Fix Mother's Milk gossip option

### DIFF
--- a/src/Bracket_60_2/sql/world/progression_60_2_the_masquerade.sql
+++ b/src/Bracket_60_2/sql/world/progression_60_2_the_masquerade.sql
@@ -411,3 +411,13 @@ UPDATE creature_text SET TextRange = 2 WHERE CreatureID = 466 AND GroupID = 7;
 UPDATE `creature_template` SET `npcflag` = `npcflag` |1|2 WHERE `entry` = 1749;
 
 UPDATE `quest_template` SET `flags` = `flags`|2|8 WHERE `id` = 6403; -- The Great Masquerade, shareable & escort flag
+
+-- Adjust quest Mother's Milk gossip option to work with changed Ragged John gossip menu
+DELETE FROM `gossip_menu_option` WHERE `MenuID`=59563 AND `OptionID`=1;
+INSERT INTO `gossip_menu_option` (`MenuID`, `OptionID`, `OptionIcon`, `OptionText`, `OptionBroadcastTextID`, `OptionType`, `OptionNpcFlag`, `ActionMenuID`, `ActionPoiID`, `BoxCoded`, `BoxMoney`, `BoxText`, `BoxBroadcastTextID`, `VerifiedBuild`) VALUES (59563, 1, 0, 'Milk me, John.', 5833, 1, 1, 2062, 0, 0, 0, '', 0, 0);
+
+DELETE FROM `conditions` WHERE `SourceTypeOrReferenceId`=15 AND `SourceGroup`=59563 AND `SourceEntry`=1;
+INSERT INTO `conditions` (`SourceTypeOrReferenceId`, `SourceGroup`, `SourceEntry`, `SourceId`, `ElseGroup`, `ConditionTypeOrReference`, `ConditionTarget`, `ConditionValue1`, `ConditionValue2`, `ConditionValue3`, `NegativeCondition`, `ErrorType`, `ErrorTextId`, `ScriptName`, `Comment`) VALUES
+(15, 59563, 1, 0, 1, 1, 0, 16468, 0, 0, 0, 0, 0, '', 'Show Gossip 59563 option 1 only if player has aura 16468'),
+(15, 59563, 1, 0, 1, 9, 0, 4866, 0, 0, 0, 0, 0, '', 'Show gossip 59563 option 1 if player does have quest 4866 taken');
+

--- a/src/Bracket_80_7/sql/world/revert_progression_60_2_the_masquerade.sql
+++ b/src/Bracket_80_7/sql/world/revert_progression_60_2_the_masquerade.sql
@@ -137,3 +137,8 @@ DELETE FROM `creature_questender` WHERE `quest` = 6502;
 UPDATE `creature_template` SET `npcflag` = `npcflag` &~1&~2 WHERE `entry` = 1749;
 
 UPDATE `quest_template` SET `flags` = `flags`&~2&~8 WHERE `id` = 6403; -- The Great Masquerade, shareable & escort flag
+
+-- Mother's Milk
+DELETE FROM `gossip_menu_option` WHERE `MenuID`=59563 AND `OptionID`=1;
+DELETE FROM `conditions` WHERE `SourceTypeOrReferenceId`=15 AND `SourceGroup`=59563 AND `SourceEntry`=1;
+


### PR DESCRIPTION
Add missing gossip option to Ragged John's changed The Masquerade gossip menu.

Closes https://github.com/chromiecraft/chromiecraft/issues/2925

Locally tested and working:
![Capture](https://user-images.githubusercontent.com/98835050/156804221-0a3c78e4-579a-4b19-bf1d-5b6a10bb2066.PNG)

