### PR TITLE
Add disable for death to Onyxia statistic until LK bracket.

### DIFF
--- a/src/Bracket_0/sql/world/progression_0_disables.sql
+++ b/src/Bracket_0/sql/world/progression_0_disables.sql
@@ -132,4 +132,3 @@ INSERT INTO `disables` (`sourceType`, `entry`, `flags`, `params_0`, `params_1`, 
 (2, 658, 3, "", "", "Pit of Saron"),
 (2, 668, 3, "", "", "Halls of Reflection"),
 (2, 724, 15, "", "", "The Ruby Sanctum");
-

--- a/src/Bracket_0/sql/world/progression_0_disables.sql
+++ b/src/Bracket_0/sql/world/progression_0_disables.sql
@@ -116,9 +116,10 @@ INSERT INTO `disables` (`sourceType`, `entry`, `flags`, `params_0`, `params_1`, 
 (2, 602, 3, "", "", "Halls of Lighting");
 
 -- 80 level range
-DELETE FROM `disables` WHERE `entry` IN (249, 533, 603, 615, 616, 624, 631, 632, 649, 650, 658, 668, 724);
+DELETE FROM `disables` WHERE `entry` IN (249, 533, 603, 615, 616, 624, 631, 632, 649, 650, 658, 668, 724, 13276);
 INSERT INTO `disables` (`sourceType`, `entry`, `flags`, `params_0`, `params_1`, `comment`) VALUES 
 (2, 249, 3, "", "", "Onyxia Lair"),
+(4, 13276, 0, "", "", "Onyxia Lair LK Statistic"),
 (2, 533, 3, "", "", "Naxxramas"),
 (2, 603, 3, "", "", "Ulduar"),
 (2, 615, 3, "", "", "The Obsidian Sanctum"),
@@ -131,3 +132,4 @@ INSERT INTO `disables` (`sourceType`, `entry`, `flags`, `params_0`, `params_1`, 
 (2, 658, 3, "", "", "Pit of Saron"),
 (2, 668, 3, "", "", "Halls of Reflection"),
 (2, 724, 15, "", "", "The Ruby Sanctum");
+

--- a/src/Bracket_80_7/sql/world/revert_progression_80_7_onyxia.sql
+++ b/src/Bracket_80_7/sql/world/revert_progression_80_7_onyxia.sql
@@ -9,6 +9,8 @@ DELETE FROM `reference_loot_template` WHERE `Entry` IN (54001, 54002);
 
 DELETE FROM `disables` WHERE `entry` = 12559 AND `sourceType` = 4;
 
+DELETE FROM `disables` WHERE `entry` = 13276 AND `sourceType` = 4;
+
 DELETE FROM `disables` WHERE `entry` IN (12565, 12566, 12564, 12558) AND `sourceType` = 4;
 
 DELETE FROM `dungeon_access_requirements` WHERE `dungeon_access_id` = 15;


### PR DESCRIPTION
Closes https://github.com/chromiecraft/chromiecraft/issues/3614

As of right now, dying to Onyxia in her level 60 form will count as a death to her level 80 form. This PR removes that statistic until (What I think is) the appropriate bracket is reached.

Tested the disable query on its own (Without the progression module) on local AC, did count as a 10-player raid death, but not as a Lich King boss death.