### PR TITLE
feat: Allow reapplying updates on start up

### DIFF
--- a/conf/progression_system.conf.dist
+++ b/conf/progression_system.conf.dist
@@ -23,6 +23,15 @@ ProgressionSystem.LoadScripts = 1
 ProgressionSystem.LoadDatabase = 1
 
 #
+#    ProgressionSystem.ReapplyUpdates
+#        Description: Always reapply every SQL file on start up. Warning: impacts start up times.
+#        Default:     1 - Enabled
+#                     0 - Disabled
+#
+
+ProgressionSystem.ReapplyUpdates = 0
+
+#
 #    ProgressionSystem.Brackets
 #        Description: Defined what brackets should be loaded. It is a bitmask. Available mask values are present in ProgressionSystem.h
 #        Default:     0 - None

--- a/src/ProgressionSystem.cpp
+++ b/src/ProgressionSystem.cpp
@@ -34,6 +34,11 @@ public:
     {
         if (DBUpdater<LoginDatabaseConnection>::IsEnabled(updateFlags))
         {
+            if (sConfigMgr->GetOption<bool>("ProgressionSystem.ReapplyUpdates", false))
+            {
+                LoginDatabase.Query("DELETE FROM updates WHERE name LIKE '%progression%'");
+            }
+
             std::vector<std::string> loginDatabaseDirectories = GetDatabaseDirectories("auth");
             if (!loginDatabaseDirectories.empty())
             {
@@ -43,6 +48,11 @@ public:
 
         if (DBUpdater<CharacterDatabaseConnection>::IsEnabled(updateFlags))
         {
+            if (sConfigMgr->GetOption<bool>("ProgressionSystem.ReapplyUpdates", false))
+            {
+                CharacterDatabase.Query("DELETE FROM updates WHERE name LIKE '%progression%'");
+            }
+
             std::vector<std::string> charactersDatabaseDirectories = GetDatabaseDirectories("characters");
             if (!charactersDatabaseDirectories.empty())
             {
@@ -52,6 +62,11 @@ public:
 
         if (DBUpdater<WorldDatabaseConnection>::IsEnabled(updateFlags))
         {
+            if (sConfigMgr->GetOption<bool>("ProgressionSystem.ReapplyUpdates", false))
+            {
+                WorldDatabase.Query("DELETE FROM updates WHERE name LIKE '%progression%'");
+            }
+
             std::vector<std::string> worldDatabaseDirectories = GetDatabaseDirectories("world");
             if (!worldDatabaseDirectories.empty())
             {


### PR DESCRIPTION
Quite self explanatory.
This will force the execution of every sql file on every start up
Update time is impacted by the sheer amount of files executed