### PR TITLE
fix(DB/GameObjects): Tweak drop rates of nightmare fragments

### DIFF
--- a/src/Bracket_60_3_2/sql/progression_60_3_2_scarab_lord_quests.sql
+++ b/src/Bracket_60_3_2/sql/progression_60_3_2_scarab_lord_quests.sql
@@ -1,7 +1,7 @@
 -- Fix drop rate for Nightmare_corruption
-UPDATE `creature_loot_template` SET `Chance` = 1 WHERE `Item` = 21146;
-UPDATE `creature_loot_template` SET `Chance` = 1 WHERE `Item` = 21147;
-UPDATE `creature_loot_template` SET `Chance` = 1 WHERE `Item` = 21148;
+UPDATE `creature_loot_template` SET `Chance` = 5 WHERE `Item` = 21146;
+UPDATE `creature_loot_template` SET `Chance` = 5 WHERE `Item` = 21147;
+UPDATE `creature_loot_template` SET `Chance` = 5 WHERE `Item` = 21148;
 
 -- FIx drop rate for Narain's Scrying Goggles
 UPDATE `creature_loot_template` SET `Chance` = 2 WHERE `Item` = 20951;


### PR DESCRIPTION
Align with VMangos and others Classic DBs.

Close: https://github.com/chromiecraft/chromiecraft/issues/4037