### PR TITLE
(SQL): Make TBC Heroic Dungeons keys require Revered

### DIFF
--- a/src/Bracket_61_64/sql/world/progression_61_64_item_template_revered_heroic_keys.sql
+++ b/src/Bracket_61_64/sql/world/progression_61_64_item_template_revered_heroic_keys.sql
@@ -1,0 +1,9 @@
+-- Set Dungeon Heroic Keys to require Revered with their respective factions
+UPDATE `item_template` SET `RequiredReputationRank` = 6 WHERE (`entry` IN (
+30622, -- Hellfire Citadel (Alliance)
+30623, -- Coilfang Resevoir
+30633, -- Auchindoun
+30634, -- Tempest Key
+30635, -- Caverns of Time
+30637  -- Hellfire Citadel (Horde)
+);

--- a/src/Bracket_70_3_1/sql/world/progression_61_64_item_template_revered_heroic_keys_down.sql
+++ b/src/Bracket_70_3_1/sql/world/progression_61_64_item_template_revered_heroic_keys_down.sql
@@ -1,0 +1,9 @@
+-- Restore Dungeon Heroic Keys to require Honored with their respective factions
+UPDATE `item_template` SET `RequiredReputationRank` = 5 WHERE (`entry` IN (
+30622, -- Hellfire Citadel (Alliance)
+30623, -- Coilfang Resevoir
+30633, -- Auchindoun
+30634, -- Tempest Key
+30635, -- Caverns of Time
+30637  -- Hellfire Citadel (Horde)
+);


### PR DESCRIPTION
Tested ingame. Requires cleared cache to reflect changes.