### PR TITLE
Revert "(SQL): Change Swamp Gas to drop Mote of Life instead of Mote of Water until ZA"

### DIFF
--- a/src/Bracket_61_64/sql/world/progression_61_64_skinning_loot_template_SwampGas.sql
+++ b/src/Bracket_61_64/sql/world/progression_61_64_skinning_loot_template_SwampGas.sql
@@ -1,2 +1,0 @@
--- Change Mote of Water to Mote of Life (Changed in Patch 2.3.0)
-UPDATE `skinning_loot_template` SET `Item`=22575 WHERE `Entry`=80200 AND `Item`=22578;

--- a/src/Bracket_70_5/sql/world/progression_61_64_skinning_loot_template_SwampGas_down.sql
+++ b/src/Bracket_70_5/sql/world/progression_61_64_skinning_loot_template_SwampGas_down.sql
@@ -1,2 +1,0 @@
--- Restore to Mote of Water (Changed in Patch 2.3.0)
-UPDATE `skinning_loot_template` SET `Item`=22578 WHERE `Entry`=80200 AND `Item`=22575;


### PR DESCRIPTION
Reverts azerothcore/mod-progression-system#283
With this revert it'll follow Classic Progression.
To restore, run: 
```
UPDATE `skinning_loot_template` SET `Item`=22578 WHERE `Entry`=80200 AND `Item`=22575;
```