### PR TITLE
Fix Rohok and Dumphry not being trainers

### DIFF
--- a/src/Bracket_61_64/sql/world/progression_61_64_attunement_key_recovery.sql
+++ b/src/Bracket_61_64/sql/world/progression_61_64_attunement_key_recovery.sql
@@ -36,37 +36,3 @@ INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_
 (18481, 0, 6, 0, 61, 0, 100, 0, 0, 0, 0, 0, 0, 11, 54881, 0, 0, 0, 0, 0, 7, 0, 0, 0, 0, 0, 0, 0, 0, 'A\'dal - On Gossip Option 0 Selected - Cast \'Create Key to the Arcatraz\''),
 (18481, 0, 7, 8, 62, 0, 100, 0, 7966, 1, 0, 0, 0, 72, 0, 0, 0, 0, 0, 0, 7, 0, 0, 0, 0, 0, 0, 0, 0, 'A\'dal - On Gossip Option 1 Selected - Close Gossip'),
 (18481, 0, 8, 0, 61, 0, 100, 0, 0, 0, 0, 0, 0, 11, 39116, 0, 0, 0, 0, 0, 7, 0, 0, 0, 0, 0, 0, 0, 0, 'A\'dal - On Gossip Option 1 Selected - Cast \'Create Tempest Key\'');
-
--- Rohok (Shattered Halls - Horde)
-DELETE FROM `gossip_menu_option` WHERE (`MenuID` = 8760) AND (`OptionID` IN (0));
-INSERT INTO `gossip_menu_option` (`MenuID`, `OptionID`, `OptionIcon`, `OptionText`, `OptionBroadcastTextID`, `OptionType`, `OptionNpcFlag`, `ActionMenuID`, `ActionPoiID`, `BoxCoded`, `BoxMoney`, `BoxText`, `BoxBroadcastTextID`, `VerifiedBuild`) VALUES
-(8760, 0, 0, 'I\'ve lost the key to the Shattered Halls.', 22029, 1, 1, 0, 0, 0, 0, '', 0, 0);
-
-DELETE FROM `conditions` WHERE (`SourceTypeOrReferenceId` = 15) AND (`SourceGroup` = 8760);
-INSERT INTO `conditions` (`SourceTypeOrReferenceId`, `SourceGroup`, `SourceEntry`, `SourceId`, `ElseGroup`, `ConditionTypeOrReference`, `ConditionTarget`, `ConditionValue1`, `ConditionValue2`, `ConditionValue3`, `NegativeCondition`, `ErrorType`, `ErrorTextId`, `ScriptName`, `Comment`) VALUES
-(15, 8760, 0, 0, 0, 2, 0, 28395, 1, 0, 1, 0, 0, '', 'If player does not have \'Shattered Halls Key\' in in inventory'),
-(15, 8760, 0, 0, 0, 2, 0, 28395, 1, 1, 1, 0, 0, '', 'If player does not have \'Shattered Halls Key\' in in bank'),
-(15, 8760, 0, 0, 0, 8, 0, 10758, 0, 0, 0, 0, 0, '', 'If player has completed quest \'Hotter than Hell\'');
-
-UPDATE `creature_template` SET `AIName` = 'SmartAI' WHERE `entry` = 16583;
-DELETE FROM `smart_scripts` WHERE (`entryorguid` = 16583) AND (`source_type` = 0) AND (`id` IN (0, 1));
-INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_type`, `event_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `event_param5`, `action_type`, `action_param1`, `action_param2`, `action_param3`, `action_param4`, `action_param5`, `action_param6`, `target_type`, `target_param1`, `target_param2`, `target_param3`, `target_param4`, `target_x`, `target_y`, `target_z`, `target_o`, `comment`) VALUES
-(16583, 0, 0, 1, 62, 0, 100, 0, 8760, 0, 0, 0, 0, 72, 0, 0, 0, 0, 0, 0, 7, 0, 0, 0, 0, 0, 0, 0, 0, 'Rohok - On Gossip Option 0 Selected - Close Gossip'),
-(16583, 0, 1, 0, 61, 0, 100, 0, 0, 0, 0, 0, 0, 11, 54884, 0, 0, 0, 0, 0, 7, 0, 0, 0, 0, 0, 0, 0, 0, 'Rohok - On Gossip Option 0 Selected - Cast \'Create Shattered Halls Key\'');
-
--- Dumphry (Shattered Halls - Alliance)
-DELETE FROM `gossip_menu_option` WHERE (`MenuID` = 8254) AND (`OptionID` IN (0));
-INSERT INTO `gossip_menu_option` (`MenuID`, `OptionID`, `OptionIcon`, `OptionText`, `OptionBroadcastTextID`, `OptionType`, `OptionNpcFlag`, `ActionMenuID`, `ActionPoiID`, `BoxCoded`, `BoxMoney`, `BoxText`, `BoxBroadcastTextID`, `VerifiedBuild`) VALUES
-(8254, 0, 0, 'I\'ve lost the key to the Shattered Halls.', 22029, 1, 1, 0, 0, 0, 0, '', 0, 0);
-
-DELETE FROM `conditions` WHERE (`SourceTypeOrReferenceId` = 15) AND (`SourceGroup` = 8254);
-INSERT INTO `conditions` (`SourceTypeOrReferenceId`, `SourceGroup`, `SourceEntry`, `SourceId`, `ElseGroup`, `ConditionTypeOrReference`, `ConditionTarget`, `ConditionValue1`, `ConditionValue2`, `ConditionValue3`, `NegativeCondition`, `ErrorType`, `ErrorTextId`, `ScriptName`, `Comment`) VALUES
-(15, 8254, 0, 0, 0, 2, 0, 28395, 1, 0, 1, 0, 0, '', 'If player does not have \'Shattered Halls Key\' in in inventory'),
-(15, 8254, 0, 0, 0, 2, 0, 28395, 1, 1, 1, 0, 0, '', 'If player does not have \'Shattered Halls Key\' in in bank'),
-(15, 8254, 0, 0, 0, 8, 0, 10764, 0, 0, 0, 0, 0, '', 'If player has completed quest \'Hotter than Hell\'');
-
-UPDATE `creature_template` SET `AIName` = 'SmartAI' WHERE `entry` = 21209;
-DELETE FROM `smart_scripts` WHERE (`entryorguid` = 21209) AND (`source_type` = 0) AND (`id` IN (0, 1));
-INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_type`, `event_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `event_param5`, `action_type`, `action_param1`, `action_param2`, `action_param3`, `action_param4`, `action_param5`, `action_param6`, `target_type`, `target_param1`, `target_param2`, `target_param3`, `target_param4`, `target_x`, `target_y`, `target_z`, `target_o`, `comment`) VALUES
-(21209, 0, 0, 1, 62, 0, 100, 0, 8254, 0, 0, 0, 0, 72, 0, 0, 0, 0, 0, 0, 7, 0, 0, 0, 0, 0, 0, 0, 0, 'Dumphry - On Gossip Option 0 Selected - Close Gossip'),
-(21209, 0, 1, 0, 61, 0, 100, 0, 0, 0, 0, 0, 0, 11, 54884, 0, 0, 0, 0, 0, 7, 0, 0, 0, 0, 0, 0, 0, 0, 'Dumphry - On Gossip Option 0 Selected - Cast \'Create Shattered Halls Key\'');

--- a/src/Bracket_70_6_1/sql/world/progression_61_64_attunement_key_recovery_down.sql
+++ b/src/Bracket_70_6_1/sql/world/progression_61_64_attunement_key_recovery_down.sql
@@ -12,19 +12,3 @@ DELETE FROM `gossip_menu_option` WHERE (`MenuID` = 7966) AND (`OptionID` IN (0, 
 DELETE FROM `conditions` WHERE (`SourceTypeOrReferenceId` = 15) AND (`SourceGroup` = 7966);
 
 DELETE FROM `smart_scripts` WHERE (`entryorguid` = 18481) AND (`source_type` = 0) AND (`id` IN (5, 6, 7, 8));
-
--- Rohok (Shattered Halls - Horde)
-DELETE FROM `gossip_menu_option` WHERE (`MenuID` = 8760) AND (`OptionID` IN (0));
-
-DELETE FROM `conditions` WHERE (`SourceTypeOrReferenceId` = 15) AND (`SourceGroup` = 8760);
-
-UPDATE `creature_template` SET `AIName` = '' WHERE `entry` = 16583;
-DELETE FROM `smart_scripts` WHERE (`entryorguid` = 16583) AND (`source_type` = 0) AND (`id` IN (0, 1));
-
--- Dumphry (Shattered Halls - Alliance)
-DELETE FROM `gossip_menu_option` WHERE (`MenuID` = 8254) AND (`OptionID` IN (0));
-
-DELETE FROM `conditions` WHERE (`SourceTypeOrReferenceId` = 15) AND (`SourceGroup` = 8254);
-
-UPDATE `creature_template` SET `AIName` = '' WHERE `entry` = 21209;
-DELETE FROM `smart_scripts` WHERE (`entryorguid` = 21209) AND (`source_type` = 0) AND (`id` IN (0, 1));


### PR DESCRIPTION
Please run:

```
-- Rohok (Shattered Halls - Horde)
DELETE FROM `gossip_menu_option` WHERE (`MenuID` = 8760);

DELETE FROM `conditions` WHERE (`SourceTypeOrReferenceId` = 15) AND (`SourceGroup` = 8760);

UPDATE `creature_template` SET `AIName` = '' WHERE `entry` = 16583;
DELETE FROM `smart_scripts` WHERE (`entryorguid` = 16583) AND (`source_type` = 0) AND (`id` IN (0, 1));

-- Dumphry (Shattered Halls - Alliance)
DELETE FROM `gossip_menu_option` WHERE (`MenuID` = 8254);

DELETE FROM `conditions` WHERE (`SourceTypeOrReferenceId` = 15) AND (`SourceGroup` = 8254);

UPDATE `creature_template` SET `AIName` = '' WHERE `entry` = 21209;
DELETE FROM `smart_scripts` WHERE (`entryorguid` = 21209) AND (`source_type` = 0) AND (`id` IN (0, 1));
```

If I cannot find a fix for it I'll add it to the vendor with conditions