### PR TITLE
(SQL): Use new disables type to disable loot drops.

### DIFF
--- a/src/Bracket_61_64/sql/world/progression_61_64_faction_Netherwing.sql
+++ b/src/Bracket_61_64/sql/world/progression_61_64_faction_Netherwing.sql
@@ -47,13 +47,49 @@ UPDATE `gameobject` SET `phaseMask`=16384 WHERE `id` IN (
 );
 
 -- Disable Netherwing Crystal drops
-DELETE FROM `creature_loot_template` WHERE `Item`=32427 AND `Entry` IN (23169,23264,23267,23269,23285,23286,23290,23305,23324,23326,23501);
+DELETE FROM `conditions` WHERE (`SourceTypeOrReferenceId` = 1) AND (`SourceEntry` = 32427) AND (`ConditionTypeOrReference` = 4) AND (`ConditionValue1` = 876);
+INSERT INTO `conditions` (`SourceTypeOrReferenceId`, `SourceGroup`, `SourceEntry`, `SourceId`, `ElseGroup`, `ConditionTypeOrReference`, `ConditionTarget`, `ConditionValue1`, `ConditionValue2`, `ConditionValue3`, `NegativeCondition`, `ErrorType`, `ErrorTextId`, `ScriptName`, `Comment`) VALUES
+(1, 23169, 32427, 0, 0, 4, 0, 876, 0, 0, 0, 0, 0, '', 'Disable Item Drop 32427'),
+(1, 23264, 32427, 0, 0, 4, 0, 876, 0, 0, 0, 0, 0, '', 'Disable Item Drop 32427'),
+(1, 23267, 32427, 0, 0, 4, 0, 876, 0, 0, 0, 0, 0, '', 'Disable Item Drop 32427'),
+(1, 23269, 32427, 0, 0, 4, 0, 876, 0, 0, 0, 0, 0, '', 'Disable Item Drop 32427'),
+(1, 23285, 32427, 0, 0, 4, 0, 876, 0, 0, 0, 0, 0, '', 'Disable Item Drop 32427'),
+(1, 23286, 32427, 0, 0, 4, 0, 876, 0, 0, 0, 0, 0, '', 'Disable Item Drop 32427'),
+(1, 23290, 32427, 0, 0, 4, 0, 876, 0, 0, 0, 0, 0, '', 'Disable Item Drop 32427'),
+(1, 23305, 32427, 0, 0, 4, 0, 876, 0, 0, 0, 0, 0, '', 'Disable Item Drop 32427'),
+(1, 23324, 32427, 0, 0, 4, 0, 876, 0, 0, 0, 0, 0, '', 'Disable Item Drop 32427'),
+(1, 23326, 32427, 0, 0, 4, 0, 876, 0, 0, 0, 0, 0, '', 'Disable Item Drop 32427'),
+(1, 23501, 32427, 0, 0, 4, 0, 876, 0, 0, 0, 0, 0, '', 'Disable Item Drop 32427');
+
+-- Disable Netherwing Egg drops
+DELETE FROM `conditions` WHERE (`SourceTypeOrReferenceId` = 1) AND (`SourceEntry` = 32506) AND (`ConditionTypeOrReference` = 4) AND (`ConditionValue1` = 876);
+INSERT INTO `conditions` (`SourceTypeOrReferenceId`, `SourceGroup`, `SourceEntry`, `SourceId`, `ElseGroup`, `ConditionTypeOrReference`, `ConditionTarget`, `ConditionValue1`, `ConditionValue2`, `ConditionValue3`, `NegativeCondition`, `ErrorType`, `ErrorTextId`, `ScriptName`, `Comment`) VALUES
+(1, 23169, 32506, 0, 0, 4, 0, 876, 0, 0, 0, 0, 0, '', 'Disable Item Drop 32506'),
+(1, 23264, 32506, 0, 0, 4, 0, 876, 0, 0, 0, 0, 0, '', 'Disable Item Drop 32506'),
+(1, 23285, 32506, 0, 0, 4, 0, 876, 0, 0, 0, 0, 0, '', 'Disable Item Drop 32506'),
+(1, 23286, 32506, 0, 0, 4, 0, 876, 0, 0, 0, 0, 0, '', 'Disable Item Drop 32506'),
+(1, 23290, 32506, 0, 0, 4, 0, 876, 0, 0, 0, 0, 0, '', 'Disable Item Drop 32506'),
+(1, 23305, 32506, 0, 0, 4, 0, 876, 0, 0, 0, 0, 0, '', 'Disable Item Drop 32506'),
+(1, 23324, 32506, 0, 0, 4, 0, 876, 0, 0, 0, 0, 0, '', 'Disable Item Drop 32506'),
+(1, 23326, 32506, 0, 0, 4, 0, 876, 0, 0, 0, 0, 0, '', 'Disable Item Drop 32506'),
+(1, 23501, 32506, 0, 0, 4, 0, 876, 0, 0, 0, 0, 0, '', 'Disable Item Drop 32506');
 
 -- Disable Nethermine Flayer Hide (32470)
-DELETE FROM `creature_loot_template` WHERE `Item`=32470 AND `Entry` IN (23169, 23326);
-DELETE FROM `skinning_loot_template` WHERE `Entry`=70165 AND `Item`=32470;
+DELETE FROM `conditions` WHERE (`SourceTypeOrReferenceId` = 1) AND (`SourceEntry` = 32470) AND (`ConditionTypeOrReference` = 4) AND (`ConditionValue1` = 876);
+INSERT INTO `conditions` (`SourceTypeOrReferenceId`, `SourceGroup`, `SourceEntry`, `SourceId`, `ElseGroup`, `ConditionTypeOrReference`, `ConditionTarget`, `ConditionValue1`, `ConditionValue2`, `ConditionValue3`, `NegativeCondition`, `ErrorType`, `ErrorTextId`, `ScriptName`, `Comment`) VALUES
+(1, 23169, 32470, 0, 0, 4, 0, 876, 0, 0, 0, 0, 0, '', 'Disable Item Drop 32470'),
+(1, 23326, 32470, 0, 0, 4, 0, 876, 0, 0, 0, 0, 0, '', 'Disable Item Drop 32470');
+DELETE FROM `conditions` WHERE (`SourceTypeOrReferenceId` = 11) AND (`SourceEntry` = 32470) AND (`ConditionTypeOrReference` = 4) AND (`ConditionValue1` = 876);
+INSERT INTO `conditions` (`SourceTypeOrReferenceId`, `SourceGroup`, `SourceEntry`, `SourceId`, `ElseGroup`, `ConditionTypeOrReference`, `ConditionTarget`, `ConditionValue1`, `ConditionValue2`, `ConditionValue3`, `NegativeCondition`, `ErrorType`, `ErrorTextId`, `ScriptName`, `Comment`) VALUES
+(11, 70165, 32470, 0, 0, 4, 0, 876, 0, 0, 0, 0, 0, '', 'Disable Item Drop 32470');
 
 -- Remove non-trash drops from Sludge-Covered Object
-DELETE FROM `item_loot_template` WHERE `Entry`=32724 AND `Item` IN (32464, 32468, 32470, 32726);
+DELETE FROM `conditions` WHERE (`SourceTypeOrReferenceId` = 5) AND (`SourceEntry` IN (32464, 32468, 32470, 32726)) AND (`ConditionTypeOrReference` = 4) AND (`ConditionValue1` = 876);
+INSERT INTO `conditions` (`SourceTypeOrReferenceId`, `SourceGroup`, `SourceEntry`, `SourceId`, `ElseGroup`, `ConditionTypeOrReference`, `ConditionTarget`, `ConditionValue1`, `ConditionValue2`, `ConditionValue3`, `NegativeCondition`, `ErrorType`, `ErrorTextId`, `ScriptName`, `Comment`) VALUES
+(5, 32724, 32464, 0, 0, 4, 0, 876, 0, 0, 0, 0, 0, '', 'Disable Item Drop 32506'),
+(5, 32724, 32468, 0, 0, 4, 0, 876, 0, 0, 0, 0, 0, '', 'Disable Item Drop 32506'),
+(5, 32724, 32470, 0, 0, 4, 0, 876, 0, 0, 0, 0, 0, '', 'Disable Item Drop 32506'),
+(5, 32724, 32726, 0, 0, 4, 0, 876, 0, 0, 0, 0, 0, '', 'Disable Item Drop 32506');
+
 -- Set Sludge-Covered Object to Quality 0 to not mislead players
 UPDATE `item_template` SET `Quality` = 0 WHERE (`entry` = 32724);

--- a/src/Bracket_61_64/sql/world/progression_61_64_faction_Netherwing.sql
+++ b/src/Bracket_61_64/sql/world/progression_61_64_faction_Netherwing.sql
@@ -46,50 +46,15 @@ UPDATE `gameobject` SET `phaseMask`=16384 WHERE `id` IN (
 185881  -- Netherdust Bush
 );
 
--- Disable Netherwing Crystal drops
-DELETE FROM `conditions` WHERE (`SourceTypeOrReferenceId` = 1) AND (`SourceEntry` = 32427) AND (`ConditionTypeOrReference` = 4) AND (`ConditionValue1` = 876);
-INSERT INTO `conditions` (`SourceTypeOrReferenceId`, `SourceGroup`, `SourceEntry`, `SourceId`, `ElseGroup`, `ConditionTypeOrReference`, `ConditionTarget`, `ConditionValue1`, `ConditionValue2`, `ConditionValue3`, `NegativeCondition`, `ErrorType`, `ErrorTextId`, `ScriptName`, `Comment`) VALUES
-(1, 23169, 32427, 0, 0, 4, 0, 876, 0, 0, 0, 0, 0, '', 'Disable Item Drop 32427'),
-(1, 23264, 32427, 0, 0, 4, 0, 876, 0, 0, 0, 0, 0, '', 'Disable Item Drop 32427'),
-(1, 23267, 32427, 0, 0, 4, 0, 876, 0, 0, 0, 0, 0, '', 'Disable Item Drop 32427'),
-(1, 23269, 32427, 0, 0, 4, 0, 876, 0, 0, 0, 0, 0, '', 'Disable Item Drop 32427'),
-(1, 23285, 32427, 0, 0, 4, 0, 876, 0, 0, 0, 0, 0, '', 'Disable Item Drop 32427'),
-(1, 23286, 32427, 0, 0, 4, 0, 876, 0, 0, 0, 0, 0, '', 'Disable Item Drop 32427'),
-(1, 23290, 32427, 0, 0, 4, 0, 876, 0, 0, 0, 0, 0, '', 'Disable Item Drop 32427'),
-(1, 23305, 32427, 0, 0, 4, 0, 876, 0, 0, 0, 0, 0, '', 'Disable Item Drop 32427'),
-(1, 23324, 32427, 0, 0, 4, 0, 876, 0, 0, 0, 0, 0, '', 'Disable Item Drop 32427'),
-(1, 23326, 32427, 0, 0, 4, 0, 876, 0, 0, 0, 0, 0, '', 'Disable Item Drop 32427'),
-(1, 23501, 32427, 0, 0, 4, 0, 876, 0, 0, 0, 0, 0, '', 'Disable Item Drop 32427');
-
--- Disable Netherwing Egg drops
-DELETE FROM `conditions` WHERE (`SourceTypeOrReferenceId` = 1) AND (`SourceEntry` = 32506) AND (`ConditionTypeOrReference` = 4) AND (`ConditionValue1` = 876);
-INSERT INTO `conditions` (`SourceTypeOrReferenceId`, `SourceGroup`, `SourceEntry`, `SourceId`, `ElseGroup`, `ConditionTypeOrReference`, `ConditionTarget`, `ConditionValue1`, `ConditionValue2`, `ConditionValue3`, `NegativeCondition`, `ErrorType`, `ErrorTextId`, `ScriptName`, `Comment`) VALUES
-(1, 23169, 32506, 0, 0, 4, 0, 876, 0, 0, 0, 0, 0, '', 'Disable Item Drop 32506'),
-(1, 23264, 32506, 0, 0, 4, 0, 876, 0, 0, 0, 0, 0, '', 'Disable Item Drop 32506'),
-(1, 23285, 32506, 0, 0, 4, 0, 876, 0, 0, 0, 0, 0, '', 'Disable Item Drop 32506'),
-(1, 23286, 32506, 0, 0, 4, 0, 876, 0, 0, 0, 0, 0, '', 'Disable Item Drop 32506'),
-(1, 23290, 32506, 0, 0, 4, 0, 876, 0, 0, 0, 0, 0, '', 'Disable Item Drop 32506'),
-(1, 23305, 32506, 0, 0, 4, 0, 876, 0, 0, 0, 0, 0, '', 'Disable Item Drop 32506'),
-(1, 23324, 32506, 0, 0, 4, 0, 876, 0, 0, 0, 0, 0, '', 'Disable Item Drop 32506'),
-(1, 23326, 32506, 0, 0, 4, 0, 876, 0, 0, 0, 0, 0, '', 'Disable Item Drop 32506'),
-(1, 23501, 32506, 0, 0, 4, 0, 876, 0, 0, 0, 0, 0, '', 'Disable Item Drop 32506');
-
--- Disable Nethermine Flayer Hide (32470)
-DELETE FROM `conditions` WHERE (`SourceTypeOrReferenceId` = 1) AND (`SourceEntry` = 32470) AND (`ConditionTypeOrReference` = 4) AND (`ConditionValue1` = 876);
-INSERT INTO `conditions` (`SourceTypeOrReferenceId`, `SourceGroup`, `SourceEntry`, `SourceId`, `ElseGroup`, `ConditionTypeOrReference`, `ConditionTarget`, `ConditionValue1`, `ConditionValue2`, `ConditionValue3`, `NegativeCondition`, `ErrorType`, `ErrorTextId`, `ScriptName`, `Comment`) VALUES
-(1, 23169, 32470, 0, 0, 4, 0, 876, 0, 0, 0, 0, 0, '', 'Disable Item Drop 32470'),
-(1, 23326, 32470, 0, 0, 4, 0, 876, 0, 0, 0, 0, 0, '', 'Disable Item Drop 32470');
-DELETE FROM `conditions` WHERE (`SourceTypeOrReferenceId` = 11) AND (`SourceEntry` = 32470) AND (`ConditionTypeOrReference` = 4) AND (`ConditionValue1` = 876);
-INSERT INTO `conditions` (`SourceTypeOrReferenceId`, `SourceGroup`, `SourceEntry`, `SourceId`, `ElseGroup`, `ConditionTypeOrReference`, `ConditionTarget`, `ConditionValue1`, `ConditionValue2`, `ConditionValue3`, `NegativeCondition`, `ErrorType`, `ErrorTextId`, `ScriptName`, `Comment`) VALUES
-(11, 70165, 32470, 0, 0, 4, 0, 876, 0, 0, 0, 0, 0, '', 'Disable Item Drop 32470');
-
--- Remove non-trash drops from Sludge-Covered Object
-DELETE FROM `conditions` WHERE (`SourceTypeOrReferenceId` = 5) AND (`SourceEntry` IN (32464, 32468, 32470, 32726)) AND (`ConditionTypeOrReference` = 4) AND (`ConditionValue1` = 876);
-INSERT INTO `conditions` (`SourceTypeOrReferenceId`, `SourceGroup`, `SourceEntry`, `SourceId`, `ElseGroup`, `ConditionTypeOrReference`, `ConditionTarget`, `ConditionValue1`, `ConditionValue2`, `ConditionValue3`, `NegativeCondition`, `ErrorType`, `ErrorTextId`, `ScriptName`, `Comment`) VALUES
-(5, 32724, 32464, 0, 0, 4, 0, 876, 0, 0, 0, 0, 0, '', 'Disable Item Drop 32506'),
-(5, 32724, 32468, 0, 0, 4, 0, 876, 0, 0, 0, 0, 0, '', 'Disable Item Drop 32506'),
-(5, 32724, 32470, 0, 0, 4, 0, 876, 0, 0, 0, 0, 0, '', 'Disable Item Drop 32506'),
-(5, 32724, 32726, 0, 0, 4, 0, 876, 0, 0, 0, 0, 0, '', 'Disable Item Drop 32506');
+-- Disable Netherwing Item drops
+DELETE FROM `disables` WHERE `sourceType`=10 AND `entry` IN (32427, 32464, 32468, 32470, 32506, 32726);
+INSERT INTO `disables` (`sourceType`, `entry`, `comment`) VALUES
+(10, 32427, 'Disable Netherwing Item Netherwing Crystal'),
+(10, 32464, 'Disable Netherwing Item Nethercite Ore'),
+(10, 32468, 'Disable Netherwing Item Netherdust Pollen'),
+(10, 32470, 'Disable Netherwing Item Nethermine Flayer Hide'),
+(10, 32506, 'Disable Netherwing Item Netherwing Egg'),
+(10, 32726, 'Disable Netherwing Item Murkblood Escape Plans');
 
 -- Set Sludge-Covered Object to Quality 0 to not mislead players
 UPDATE `item_template` SET `Quality` = 0 WHERE (`entry` = 32724);

--- a/src/Bracket_61_64/sql/world/progression_61_64_faction_ShatariSkyguard.sql
+++ b/src/Bracket_61_64/sql/world/progression_61_64_faction_ShatariSkyguard.sql
@@ -34,12 +34,6 @@ INSERT INTO `disables` (`sourceType`, `entry`, `comment`) VALUES
 (1, 11885, 'Adversarial Blood');
 
 -- Disable Shadow Dust drops
-DELETE FROM `conditions` WHERE (`SourceTypeOrReferenceId` = 1) AND (`SourceEntry` = 32388) AND (`ConditionTypeOrReference` = 4) AND (`ConditionValue1` = 876);
-INSERT INTO `conditions` (`SourceTypeOrReferenceId`, `SourceGroup`, `SourceEntry`, `SourceId`, `ElseGroup`, `ConditionTypeOrReference`, `ConditionTarget`, `ConditionValue1`, `ConditionValue2`, `ConditionValue3`, `NegativeCondition`, `ErrorType`, `ErrorTextId`, `ScriptName`, `Comment`) VALUES
-(1, 21644, 32388, 0, 0, 4, 0, 876, 0, 0, 0, 0, 0, '', 'Disable Item Drop 32388'),
-(1, 21649, 32388, 0, 0, 4, 0, 876, 0, 0, 0, 0, 0, '', 'Disable Item Drop 32388'),
-(1, 21650, 32388, 0, 0, 4, 0, 876, 0, 0, 0, 0, 0, '', 'Disable Item Drop 32388'),
-(1, 21911, 32388, 0, 0, 4, 0, 876, 0, 0, 0, 0, 0, '', 'Disable Item Drop 32388'),
-(1, 23066, 32388, 0, 0, 4, 0, 876, 0, 0, 0, 0, 0, '', 'Disable Item Drop 32388'),
-(1, 23067, 32388, 0, 0, 4, 0, 876, 0, 0, 0, 0, 0, '', 'Disable Item Drop 32388'),
-(1, 23068, 32388, 0, 0, 4, 0, 876, 0, 0, 0, 0, 0, '', 'Disable Item Drop 32388');
+DELETE FROM `disables` WHERE `sourceType`=10 AND `entry` IN (32388);
+INSERT INTO `disables` (`sourceType`, `entry`, `comment`) VALUES
+(10, 32388, 'Disable Sha\'tari Skyguard Item Shadow Dust');

--- a/src/Bracket_61_64/sql/world/progression_61_64_faction_ShatariSkyguard.sql
+++ b/src/Bracket_61_64/sql/world/progression_61_64_faction_ShatariSkyguard.sql
@@ -33,5 +33,13 @@ INSERT INTO `disables` (`sourceType`, `entry`, `comment`) VALUES
 (1, 11119, 'Assault on Bash\'ir Landing!'),
 (1, 11885, 'Adversarial Blood');
 
--- Remove Shadow Dust from the drop list
-DELETE FROM `creature_loot_template` WHERE `Item`=32388 AND `Entry` IN (21644, 21649, 21650, 21911, 23066, 23067, 23068);
+-- Disable Shadow Dust drops
+DELETE FROM `conditions` WHERE (`SourceTypeOrReferenceId` = 1) AND (`SourceEntry` = 32388) AND (`ConditionTypeOrReference` = 4) AND (`ConditionValue1` = 876);
+INSERT INTO `conditions` (`SourceTypeOrReferenceId`, `SourceGroup`, `SourceEntry`, `SourceId`, `ElseGroup`, `ConditionTypeOrReference`, `ConditionTarget`, `ConditionValue1`, `ConditionValue2`, `ConditionValue3`, `NegativeCondition`, `ErrorType`, `ErrorTextId`, `ScriptName`, `Comment`) VALUES
+(1, 21644, 32388, 0, 0, 4, 0, 876, 0, 0, 0, 0, 0, '', 'Disable Item Drop 32388'),
+(1, 21649, 32388, 0, 0, 4, 0, 876, 0, 0, 0, 0, 0, '', 'Disable Item Drop 32388'),
+(1, 21650, 32388, 0, 0, 4, 0, 876, 0, 0, 0, 0, 0, '', 'Disable Item Drop 32388'),
+(1, 21911, 32388, 0, 0, 4, 0, 876, 0, 0, 0, 0, 0, '', 'Disable Item Drop 32388'),
+(1, 23066, 32388, 0, 0, 4, 0, 876, 0, 0, 0, 0, 0, '', 'Disable Item Drop 32388'),
+(1, 23067, 32388, 0, 0, 4, 0, 876, 0, 0, 0, 0, 0, '', 'Disable Item Drop 32388'),
+(1, 23068, 32388, 0, 0, 4, 0, 876, 0, 0, 0, 0, 0, '', 'Disable Item Drop 32388');

--- a/src/Bracket_61_64/sql/world/progression_61_64_faction_ShatariSkyguard.sql
+++ b/src/Bracket_61_64/sql/world/progression_61_64_faction_ShatariSkyguard.sql
@@ -33,7 +33,8 @@ INSERT INTO `disables` (`sourceType`, `entry`, `comment`) VALUES
 (1, 11119, 'Assault on Bash\'ir Landing!'),
 (1, 11885, 'Adversarial Blood');
 
--- Disable Shadow Dust drops
-DELETE FROM `disables` WHERE `sourceType`=10 AND `entry` IN (32388);
+-- Disable Item drops
+DELETE FROM `disables` WHERE `sourceType`=10 AND `entry` IN (32388, 32620);
 INSERT INTO `disables` (`sourceType`, `entry`, `comment`) VALUES
-(10, 32388, 'Disable Sha\'tari Skyguard Item Shadow Dust');
+(10, 32388, 'Disable Sha\'tari Skyguard Item Shadow Dust'),
+(10, 32620, 'Disable Sha\'tari Skyguard Item Time-Lost Scroll');

--- a/src/Bracket_70_3_2/sql/world/progression_61_64_faction_ShatariSkyguard_down.sql
+++ b/src/Bracket_70_3_2/sql/world/progression_61_64_faction_ShatariSkyguard_down.sql
@@ -30,5 +30,5 @@ UPDATE `creature` SET `phasemask` = 1 WHERE `id1` IN (22987, 23449) AND `guid` I
 -- Restore Sha'tari Skyguard quests
 DELETE FROM `disables` WHERE `sourceType`=1 AND `entry` IN (11004,11005,11006,11008,11010,11021,11023,11024,11028,11029,11056,11062,11065,11066,11072,11073,11074,11078,11085,11093,11096,11098,11102,11119,11885);
 
--- Restore Shadow Dust drops
-DELETE FROM `conditions` WHERE (`SourceTypeOrReferenceId` = 1) AND (`SourceEntry` = 32388) AND (`ConditionTypeOrReference` = 4) AND (`ConditionValue1` = 876);
+-- Enable Shadow Dust drops
+DELETE FROM `disables` WHERE `sourceType`=10 AND `entry` IN (32388);

--- a/src/Bracket_70_3_2/sql/world/progression_61_64_faction_ShatariSkyguard_down.sql
+++ b/src/Bracket_70_3_2/sql/world/progression_61_64_faction_ShatariSkyguard_down.sql
@@ -30,13 +30,5 @@ UPDATE `creature` SET `phasemask` = 1 WHERE `id1` IN (22987, 23449) AND `guid` I
 -- Restore Sha'tari Skyguard quests
 DELETE FROM `disables` WHERE `sourceType`=1 AND `entry` IN (11004,11005,11006,11008,11010,11021,11023,11024,11028,11029,11056,11062,11065,11066,11072,11073,11074,11078,11085,11093,11096,11098,11102,11119,11885);
 
--- Restore Shadow Dust to the drop list
-DELETE FROM `creature_loot_template` WHERE `Item`=32388 AND `Entry` IN (21644, 21649, 21650, 21911, 23066, 23067, 23068);
-INSERT INTO `creature_loot_template` (`Entry`, `Item`, `Reference`, `Chance`, `QuestRequired`, `LootMode`, `GroupId`, `MinCount`, `MaxCount`, `Comment`) VALUES
-(21644, 32388, 0, 33, 0, 1, 0, 1, 1, 'Skettis Wing Guard - Shadow Dust'),
-(21649, 32388, 0, 33, 0, 1, 0, 1, 1, 'Skettis Windwalker - Shadow Dust'),
-(21650, 32388, 0, 33, 0, 1, 0, 1, 1, 'Skettis Talonite - Shadow Dust'),
-(21911, 32388, 0, 33, 0, 1, 0, 1, 1, 'Skettis Soulcaller - Shadow Dust'),
-(23066, 32388, 0, 33, 0, 1, 0, 1, 1, 'Talonpriest Ishaal - Shadow Dust'),
-(23067, 32388, 0, 33, 0, 1, 0, 1, 1, 'Talonpriest Skizzik - Shadow Dust'),
-(23068, 32388, 0, 33, 0, 1, 0, 1, 1, 'Talonpriest Zellek - Shadow Dust');
+-- Restore Shadow Dust drops
+DELETE FROM `conditions` WHERE (`SourceTypeOrReferenceId` = 1) AND (`SourceEntry` = 32388) AND (`ConditionTypeOrReference` = 4) AND (`ConditionValue1` = 876);

--- a/src/Bracket_70_3_2/sql/world/progression_61_64_faction_ShatariSkyguard_down.sql
+++ b/src/Bracket_70_3_2/sql/world/progression_61_64_faction_ShatariSkyguard_down.sql
@@ -30,5 +30,5 @@ UPDATE `creature` SET `phasemask` = 1 WHERE `id1` IN (22987, 23449) AND `guid` I
 -- Restore Sha'tari Skyguard quests
 DELETE FROM `disables` WHERE `sourceType`=1 AND `entry` IN (11004,11005,11006,11008,11010,11021,11023,11024,11028,11029,11056,11062,11065,11066,11072,11073,11074,11078,11085,11093,11096,11098,11102,11119,11885);
 
--- Enable Shadow Dust drops
-DELETE FROM `disables` WHERE `sourceType`=10 AND `entry` IN (32388);
+-- Enable Item drops
+DELETE FROM `disables` WHERE `sourceType`=10 AND `entry` IN (32388, 32620);

--- a/src/Bracket_70_4_1/sql/world/progression_61_64_faction_Netherwing_down.sql
+++ b/src/Bracket_70_4_1/sql/world/progression_61_64_faction_Netherwing_down.sql
@@ -9,35 +9,17 @@ UPDATE `gameobject` SET `phaseMask`=1 WHERE `id` IN (
 );
 
 -- Enable Netherwing Crystal drops
-DELETE FROM `creature_loot_template` WHERE `Item`=32427 AND `Entry` IN (23169,23264,23267,23269,23285,23286,23290,23305,23324,23326,23501);
-INSERT INTO `creature_loot_template` (`Entry`, `Item`, `Reference`, `Chance`, `QuestRequired`, `LootMode`, `GroupId`, `MinCount`, `MaxCount`, `Comment`) VALUES
-(23169, 32427, 0, 32.9, 0, 1, 0, 1, 2, 'Nethermine Flayer - Netherwing Crystal'),
-(23264, 32427, 0, 33.2, 0, 1, 0, 1, 2, 'Overmine Flayer - Netherwing Crystal'),
-(23267, 32427, 0, 19.2, 0, 1, 0, 1, 2, 'Arvoar the Rapacious - Netherwing Crystal'),
-(23269, 32427, 0, 34.6, 0, 1, 0, 1, 2, 'Barash the Den Mother - Netherwing Crystal'),
-(23285, 32427, 0, 32.5, 0, 1, 0, 1, 2, 'Nethermine Burster - Netherwing Crystal'),
-(23286, 32427, 0, 32.1, 0, 1, 0, 1, 2, 'Black Blood of Draenor - Netherwing Crystal'),
-(23290, 32427, 0, 31.3, 0, 1, 0, 1, 2, 'Draenor Blood Terror - Netherwing Crystal'),
-(23305, 32427, 0, 32.7, 0, 1, 0, 1, 2, 'Crazed Murkblood Foreman - Netherwing Crystal'),
-(23324, 32427, 0, 33.4, 0, 1, 0, 1, 2, 'Crazed Murkblood Miner - Netherwing Crystal'),
-(23326, 32427, 0, 31.9, 0, 1, 0, 1, 2, 'Nethermine Ravager - Netherwing Crystal'),
-(23501, 32427, 0, 33.5, 0, 1, 0, 1, 2, 'Netherwing Ray - Netherwing Crystal');
+DELETE FROM `conditions` WHERE (`SourceTypeOrReferenceId` = 1) AND (`SourceEntry` = 32427) AND (`ConditionTypeOrReference` = 4) AND (`ConditionValue1` = 876);
+
+-- Disable Netherwing Egg drops
+DELETE FROM `conditions` WHERE (`SourceTypeOrReferenceId` = 1) AND (`SourceEntry` = 32506) AND (`ConditionTypeOrReference` = 4) AND (`ConditionValue1` = 876);
 
 -- Enable Nethermine Flayer Hide (32470)
-DELETE FROM `creature_loot_template` WHERE `Item`=32470 AND `Entry` IN (23169, 23326);
-INSERT INTO `creature_loot_template` (`Entry`, `Item`, `Reference`, `Chance`, `QuestRequired`, `LootMode`, `GroupId`, `MinCount`, `MaxCount`, `Comment`) VALUES
-(23169, 32470, 0, 0.1, 0, 1, 0, 1, 1, 'Nethermine Flayer - Nethermine Flayer Hide'),
-(23326, 32470, 0, 0.1, 0, 1, 0, 1, 1, 'Nethermine Ravager - Nethermine Flayer Hide');
-DELETE FROM `skinning_loot_template` WHERE `Entry`=70165 AND `Item`=32470;
-INSERT INTO `skinning_loot_template` (`Entry`, `Item`, `Reference`, `Chance`, `QuestRequired`, `LootMode`, `GroupId`, `MinCount`, `MaxCount`, `Comment`) VALUES
-(70165, 32470, 0, 33, 0, 1, 1, 1, 1, NULL);
+DELETE FROM `conditions` WHERE (`SourceTypeOrReferenceId` = 1) AND (`SourceEntry` = 32470) AND (`ConditionTypeOrReference` = 4) AND (`ConditionValue1` = 876);
+DELETE FROM `conditions` WHERE (`SourceTypeOrReferenceId` = 11) AND (`SourceEntry` = 32470) AND (`ConditionTypeOrReference` = 4) AND (`ConditionValue1` = 876);
 
 -- Restore non-trash drops from Sludge-Covered Object
-DELETE FROM `item_loot_template` WHERE `Entry`=32724 AND `Item` IN (32464, 32468, 32470, 32726);
-INSERT INTO `item_loot_template` (`Entry`, `Item`, `Reference`, `Chance`, `QuestRequired`, `LootMode`, `GroupId`, `MinCount`, `MaxCount`, `Comment`) VALUES
-(32724, 32464, 0, 5.8, 0, 1, 0, 1, 5, 'Sludge-covered Object - Nethercite Ore'),
-(32724, 32468, 0, 5.3, 0, 1, 0, 1, 5, 'Sludge-covered Object - Netherdust Pollen'),
-(32724, 32470, 0, 5.5, 0, 1, 0, 1, 5, 'Sludge-covered Object - Nethermine Flayer Hide'),
-(32724, 32726, 0, 1.5, 0, 1, 0, 1, 1, 'Sludge-covered Object - Murkblood Escape Plans');
+DELETE FROM `conditions` WHERE (`SourceTypeOrReferenceId` = 5) AND (`SourceEntry` IN (32464, 32468, 32470, 32726)) AND (`ConditionTypeOrReference` = 4) AND (`ConditionValue1` = 876);
+
 -- Set Sludge-Covered Object to Quality back to 1
 UPDATE `item_template` SET `Quality` = 1 WHERE (`entry` = 32724);

--- a/src/Bracket_70_4_1/sql/world/progression_61_64_faction_Netherwing_down.sql
+++ b/src/Bracket_70_4_1/sql/world/progression_61_64_faction_Netherwing_down.sql
@@ -8,18 +8,8 @@ UPDATE `gameobject` SET `phaseMask`=1 WHERE `id` IN (
 185881  -- Netherdust Bush
 );
 
--- Enable Netherwing Crystal drops
-DELETE FROM `conditions` WHERE (`SourceTypeOrReferenceId` = 1) AND (`SourceEntry` = 32427) AND (`ConditionTypeOrReference` = 4) AND (`ConditionValue1` = 876);
-
--- Disable Netherwing Egg drops
-DELETE FROM `conditions` WHERE (`SourceTypeOrReferenceId` = 1) AND (`SourceEntry` = 32506) AND (`ConditionTypeOrReference` = 4) AND (`ConditionValue1` = 876);
-
--- Enable Nethermine Flayer Hide (32470)
-DELETE FROM `conditions` WHERE (`SourceTypeOrReferenceId` = 1) AND (`SourceEntry` = 32470) AND (`ConditionTypeOrReference` = 4) AND (`ConditionValue1` = 876);
-DELETE FROM `conditions` WHERE (`SourceTypeOrReferenceId` = 11) AND (`SourceEntry` = 32470) AND (`ConditionTypeOrReference` = 4) AND (`ConditionValue1` = 876);
-
--- Restore non-trash drops from Sludge-Covered Object
-DELETE FROM `conditions` WHERE (`SourceTypeOrReferenceId` = 5) AND (`SourceEntry` IN (32464, 32468, 32470, 32726)) AND (`ConditionTypeOrReference` = 4) AND (`ConditionValue1` = 876);
+-- Enable Netherwing Item drops
+DELETE FROM `disables` WHERE `sourceType`=10 AND `entry` IN (32427, 32464, 32468, 32470, 32506, 32726);
 
 -- Set Sludge-Covered Object to Quality back to 1
 UPDATE `item_template` SET `Quality` = 1 WHERE (`entry` = 32724);


### PR DESCRIPTION
Please run to reset your DB:

```
DELETE FROM `creature_loot_template` WHERE `Item`=32388 AND `Entry` IN (21644, 21649, 21650, 21911, 23066, 23067, 23068);
INSERT INTO `creature_loot_template` (`Entry`, `Item`, `Reference`, `Chance`, `QuestRequired`, `LootMode`, `GroupId`, `MinCount`, `MaxCount`, `Comment`) VALUES
(21644, 32388, 0, 33, 0, 1, 0, 1, 1, 'Skettis Wing Guard - Shadow Dust'),
(21649, 32388, 0, 33, 0, 1, 0, 1, 1, 'Skettis Windwalker - Shadow Dust'),
(21650, 32388, 0, 33, 0, 1, 0, 1, 1, 'Skettis Talonite - Shadow Dust'),
(21911, 32388, 0, 33, 0, 1, 0, 1, 1, 'Skettis Soulcaller - Shadow Dust'),
(23066, 32388, 0, 33, 0, 1, 0, 1, 1, 'Talonpriest Ishaal - Shadow Dust'),
(23067, 32388, 0, 33, 0, 1, 0, 1, 1, 'Talonpriest Skizzik - Shadow Dust'),
(23068, 32388, 0, 33, 0, 1, 0, 1, 1, 'Talonpriest Zellek - Shadow Dust');

DELETE FROM `creature_loot_template` WHERE `Item`=32427 AND `Entry` IN (23169,23264,23267,23269,23285,23286,23290,23305,23324,23326,23501);
INSERT INTO `creature_loot_template` (`Entry`, `Item`, `Reference`, `Chance`, `QuestRequired`, `LootMode`, `GroupId`, `MinCount`, `MaxCount`, `Comment`) VALUES
(23169, 32427, 0, 32.9, 0, 1, 0, 1, 2, 'Nethermine Flayer - Netherwing Crystal'),
(23264, 32427, 0, 33.2, 0, 1, 0, 1, 2, 'Overmine Flayer - Netherwing Crystal'),
(23267, 32427, 0, 19.2, 0, 1, 0, 1, 2, 'Arvoar the Rapacious - Netherwing Crystal'),
(23269, 32427, 0, 34.6, 0, 1, 0, 1, 2, 'Barash the Den Mother - Netherwing Crystal'),
(23285, 32427, 0, 32.5, 0, 1, 0, 1, 2, 'Nethermine Burster - Netherwing Crystal'),
(23286, 32427, 0, 32.1, 0, 1, 0, 1, 2, 'Black Blood of Draenor - Netherwing Crystal'),
(23290, 32427, 0, 31.3, 0, 1, 0, 1, 2, 'Draenor Blood Terror - Netherwing Crystal'),
(23305, 32427, 0, 32.7, 0, 1, 0, 1, 2, 'Crazed Murkblood Foreman - Netherwing Crystal'),
(23324, 32427, 0, 33.4, 0, 1, 0, 1, 2, 'Crazed Murkblood Miner - Netherwing Crystal'),
(23326, 32427, 0, 31.9, 0, 1, 0, 1, 2, 'Nethermine Ravager - Netherwing Crystal'),
(23501, 32427, 0, 33.5, 0, 1, 0, 1, 2, 'Netherwing Ray - Netherwing Crystal');

DELETE FROM `creature_loot_template` WHERE `Item`=32470 AND `Entry` IN (23169, 23326);
INSERT INTO `creature_loot_template` (`Entry`, `Item`, `Reference`, `Chance`, `QuestRequired`, `LootMode`, `GroupId`, `MinCount`, `MaxCount`, `Comment`) VALUES
(23169, 32470, 0, 0.1, 0, 1, 0, 1, 1, 'Nethermine Flayer - Nethermine Flayer Hide'),
(23326, 32470, 0, 0.1, 0, 1, 0, 1, 1, 'Nethermine Ravager - Nethermine Flayer Hide');

DELETE FROM `skinning_loot_template` WHERE `Entry`=70165 AND `Item`=32470;
INSERT INTO `skinning_loot_template` (`Entry`, `Item`, `Reference`, `Chance`, `QuestRequired`, `LootMode`, `GroupId`, `MinCount`, `MaxCount`, `Comment`) VALUES
(70165, 32470, 0, 33, 0, 1, 1, 1, 1, NULL);

DELETE FROM `item_loot_template` WHERE `Entry`=32724 AND `Item` IN (32464, 32468, 32470, 32726);
INSERT INTO `item_loot_template` (`Entry`, `Item`, `Reference`, `Chance`, `QuestRequired`, `LootMode`, `GroupId`, `MinCount`, `MaxCount`, `Comment`) VALUES
(32724, 32464, 0, 5.8, 0, 1, 0, 1, 5, 'Sludge-covered Object - Nethercite Ore'),
(32724, 32468, 0, 5.3, 0, 1, 0, 1, 5, 'Sludge-covered Object - Netherdust Pollen'),
(32724, 32470, 0, 5.5, 0, 1, 0, 1, 5, 'Sludge-covered Object - Nethermine Flayer Hide'),
(32724, 32726, 0, 1.5, 0, 1, 0, 1, 1, 'Sludge-covered Object - Murkblood Escape Plans');
```