### PR TITLE
fix: progression loot maulgar magtheridon and gruul

### DIFF
--- a/src/Bracket_70_2_1/sql/world/progression_0_creature_loot_template_Badge_of_Justice_Phase1.sql
+++ b/src/Bracket_70_2_1/sql/world/progression_0_creature_loot_template_Badge_of_Justice_Phase1.sql
@@ -1,13 +1,12 @@
 -- Remove Badge of Justice from Phase 1 Raids
-DELETE FROM `creature_loot_template` WHERE `Entry` IN  (17225, 15690, 15688, 15689, 16524, 15691, 17533, 18168, 17521, 16457, 15687, 16152) AND (`Item` IN (29434));
-
-
+DELETE FROM `creature_loot_template` WHERE `Entry` IN  (17225, 15690, 15688, 15689, 16524, 15691, 17533, 18168, 17521, 16457, 15687, 16152, 19044, 18831, 17257) AND (`Item` IN (29434));
+-- gruul loot nerfed
 DELETE FROM `creature_loot_template` WHERE (`Entry` = 19044);
 INSERT INTO `creature_loot_template` (`Entry`, `Item`, `Reference`, `Chance`, `QuestRequired`, `LootMode`, `GroupId`, `MinCount`, `MaxCount`, `Comment`) VALUES
 (19044, 31750, 0, 100, 1, 1, 0, 1, 1, 'Gruul the Dragonkiller - Earthen Signet'),
 (19044, 34051, 34051, 100, 0, 1, 2, 1, 2, 'Gruul the Dragonkiller - (ReferenceTable)'),
 (19044, 190039, 34051, 100, 0, 1, 1, 1, 1, 'Gruul the Dragonkiller - (ReferenceTable)');
-
+-- maulgar loot nerfed
 DELETE FROM `creature_loot_template` WHERE (`Entry` = 18831);
 INSERT INTO `creature_loot_template` (`Entry`, `Item`, `Reference`, `Chance`, `QuestRequired`, `LootMode`, `GroupId`, `MinCount`, `MaxCount`, `Comment`) VALUES
 (18831, 28795, 0, 0, 0, 1, 1, 1, 1, 'High King Maulgar - Bladespire Warbands'),
@@ -17,7 +16,7 @@ INSERT INTO `creature_loot_template` (`Entry`, `Item`, `Reference`, `Chance`, `Q
 (18831, 28800, 0, 0, 0, 1, 1, 1, 1, 'High King Maulgar - Hammer of the Naaru'),
 (18831, 28801, 0, 0, 0, 1, 1, 1, 1, 'High King Maulgar - Maulgar\'s Warhelm'),
 (18831, 34050, 34050, 100, 0, 1, 1, 1, 1, 'High King Maulgar - (ReferenceTable)');
-
+-- matheridon loot nerfed
 DELETE FROM `creature_loot_template` WHERE (`Entry` = 17257);
 INSERT INTO `creature_loot_template` (`Entry`, `Item`, `Reference`, `Chance`, `QuestRequired`, `LootMode`, `GroupId`, `MinCount`, `MaxCount`, `Comment`) VALUES
 (17257, 32385, 0, 100, 0, 1, 0, 1, 1, 'Magtheridon - Magtheridon\'s Head'),

--- a/src/Bracket_70_2_1/sql/world/progression_0_creature_loot_template_Badge_of_Justice_Phase1.sql
+++ b/src/Bracket_70_2_1/sql/world/progression_0_creature_loot_template_Badge_of_Justice_Phase1.sql
@@ -1,5 +1,5 @@
 -- Remove Badge of Justice from Phase 1 Raids
-DELETE FROM `creature_loot_template` WHERE `Entry` IN  (17225, 15690, 15688, 15689, 16524, 15691, 17533, 18168, 17521, 16457, 15687, 16152, 19044, 18831, 17257) AND (`Item` IN (29434));
+DELETE FROM `creature_loot_template` WHERE `Entry` IN  (17225, 15690, 15688, 15689, 16524, 15691, 17533, 18168, 17521, 16457, 15687, 16152) AND (`Item` IN (29434));
 -- gruul loot nerfed
 DELETE FROM `creature_loot_template` WHERE (`Entry` = 19044);
 INSERT INTO `creature_loot_template` (`Entry`, `Item`, `Reference`, `Chance`, `QuestRequired`, `LootMode`, `GroupId`, `MinCount`, `MaxCount`, `Comment`) VALUES

--- a/src/Bracket_70_2_1/sql/world/progression_0_creature_loot_template_Badge_of_Justice_Phase1.sql
+++ b/src/Bracket_70_2_1/sql/world/progression_0_creature_loot_template_Badge_of_Justice_Phase1.sql
@@ -4,7 +4,6 @@ DELETE FROM `creature_loot_template` WHERE `Entry` IN  (17225, 15690, 15688, 156
 
 DELETE FROM `creature_loot_template` WHERE (`Entry` = 19044);
 INSERT INTO `creature_loot_template` (`Entry`, `Item`, `Reference`, `Chance`, `QuestRequired`, `LootMode`, `GroupId`, `MinCount`, `MaxCount`, `Comment`) VALUES
-(19044, 29434, 0, 100, 0, 1, 0, 3, 3, 'Gruul the Dragonkiller - Badge of Justice'),
 (19044, 31750, 0, 100, 1, 1, 0, 1, 1, 'Gruul the Dragonkiller - Earthen Signet'),
 (19044, 34051, 34051, 100, 0, 1, 2, 1, 2, 'Gruul the Dragonkiller - (ReferenceTable)'),
 (19044, 190039, 34051, 100, 0, 1, 1, 1, 1, 'Gruul the Dragonkiller - (ReferenceTable)');
@@ -17,12 +16,10 @@ INSERT INTO `creature_loot_template` (`Entry`, `Item`, `Reference`, `Chance`, `Q
 (18831, 28799, 0, 0, 0, 1, 1, 1, 1, 'High King Maulgar - Belt of Divine Inspiration'),
 (18831, 28800, 0, 0, 0, 1, 1, 1, 1, 'High King Maulgar - Hammer of the Naaru'),
 (18831, 28801, 0, 0, 0, 1, 1, 1, 1, 'High King Maulgar - Maulgar\'s Warhelm'),
-(18831, 29434, 0, 100, 0, 1, 0, 2, 2, 'High King Maulgar - Badge of Justice'),
 (18831, 34050, 34050, 100, 0, 1, 1, 1, 1, 'High King Maulgar - (ReferenceTable)');
 
 DELETE FROM `creature_loot_template` WHERE (`Entry` = 17257);
 INSERT INTO `creature_loot_template` (`Entry`, `Item`, `Reference`, `Chance`, `QuestRequired`, `LootMode`, `GroupId`, `MinCount`, `MaxCount`, `Comment`) VALUES
-(17257, 29434, 0, 100, 0, 1, 0, 3, 3, 'Magtheridon - Badge of Justice'),
 (17257, 32385, 0, 100, 0, 1, 0, 1, 1, 'Magtheridon - Magtheridon\'s Head'),
 (17257, 32386, 0, 100, 0, 1, 0, 1, 1, 'Magtheridon - Magtheridon\'s Head'),
 (17257, 34039, 34039, 100, 0, 1, 1, 1, 1, 'Magtheridon - (ReferenceTable)'),

--- a/src/Bracket_70_2_1/sql/world/progression_0_creature_loot_template_Badge_of_Justice_Phase1.sql
+++ b/src/Bracket_70_2_1/sql/world/progression_0_creature_loot_template_Badge_of_Justice_Phase1.sql
@@ -1,2 +1,31 @@
 -- Remove Badge of Justice from Phase 1 Raids
 DELETE FROM `creature_loot_template` WHERE `Entry` IN  (17225, 15690, 15688, 15689, 16524, 15691, 17533, 18168, 17521, 16457, 15687, 16152) AND (`Item` IN (29434));
+
+
+DELETE FROM `creature_loot_template` WHERE (`Entry` = 19044);
+INSERT INTO `creature_loot_template` (`Entry`, `Item`, `Reference`, `Chance`, `QuestRequired`, `LootMode`, `GroupId`, `MinCount`, `MaxCount`, `Comment`) VALUES
+(19044, 29434, 0, 100, 0, 1, 0, 3, 3, 'Gruul the Dragonkiller - Badge of Justice'),
+(19044, 31750, 0, 100, 1, 1, 0, 1, 1, 'Gruul the Dragonkiller - Earthen Signet'),
+(19044, 34051, 34051, 100, 0, 1, 2, 1, 2, 'Gruul the Dragonkiller - (ReferenceTable)'),
+(19044, 190039, 34051, 100, 0, 1, 1, 1, 1, 'Gruul the Dragonkiller - (ReferenceTable)');
+
+DELETE FROM `creature_loot_template` WHERE (`Entry` = 18831);
+INSERT INTO `creature_loot_template` (`Entry`, `Item`, `Reference`, `Chance`, `QuestRequired`, `LootMode`, `GroupId`, `MinCount`, `MaxCount`, `Comment`) VALUES
+(18831, 28795, 0, 0, 0, 1, 1, 1, 1, 'High King Maulgar - Bladespire Warbands'),
+(18831, 28796, 0, 0, 0, 1, 1, 1, 1, 'High King Maulgar - Malefic Mask of the Shadows'),
+(18831, 28797, 0, 0, 0, 1, 1, 1, 1, 'High King Maulgar - Brute Cloak of the Ogre-Magi'),
+(18831, 28799, 0, 0, 0, 1, 1, 1, 1, 'High King Maulgar - Belt of Divine Inspiration'),
+(18831, 28800, 0, 0, 0, 1, 1, 1, 1, 'High King Maulgar - Hammer of the Naaru'),
+(18831, 28801, 0, 0, 0, 1, 1, 1, 1, 'High King Maulgar - Maulgar\'s Warhelm'),
+(18831, 29434, 0, 100, 0, 1, 0, 2, 2, 'High King Maulgar - Badge of Justice'),
+(18831, 34050, 34050, 100, 0, 1, 1, 1, 1, 'High King Maulgar - (ReferenceTable)');
+
+DELETE FROM `creature_loot_template` WHERE (`Entry` = 17257);
+INSERT INTO `creature_loot_template` (`Entry`, `Item`, `Reference`, `Chance`, `QuestRequired`, `LootMode`, `GroupId`, `MinCount`, `MaxCount`, `Comment`) VALUES
+(17257, 29434, 0, 100, 0, 1, 0, 3, 3, 'Magtheridon - Badge of Justice'),
+(17257, 32385, 0, 100, 0, 1, 0, 1, 1, 'Magtheridon - Magtheridon\'s Head'),
+(17257, 32386, 0, 100, 0, 1, 0, 1, 1, 'Magtheridon - Magtheridon\'s Head'),
+(17257, 34039, 34039, 100, 0, 1, 1, 1, 1, 'Magtheridon - (ReferenceTable)'),
+(17257, 34845, 0, 100, 0, 1, 0, 1, 1, 'Magtheridon - Pit Lord\'s Satchel'),
+(17257, 34846, 0, 100, 0, 1, 0, 1, 1, 'Magtheridon - Black Sack of Gems'),
+(17257, 90039, 34039, 100, 0, 1, 2, 1, 2, 'Magtheridon - (ReferenceTable)');

--- a/src/Bracket_70_2_1/sql/world/progression_0_creature_loot_template_Badge_of_Justice_Phase1.sql
+++ b/src/Bracket_70_2_1/sql/world/progression_0_creature_loot_template_Badge_of_Justice_Phase1.sql
@@ -1,2 +1,2 @@
 -- Remove Badge of Justice from Phase 1 Raids
-DELETE FROM `creature_loot_template` WHERE `Entry` IN  (17225, 15690, 15688, 15689, 16524, 15691, 17533, 18168, 17521, 16457, 15687, 16152, 19044, 18831, 17257) AND (`Item` IN (29434));
+DELETE FROM `creature_loot_template` WHERE `Entry` IN  (17225, 15690, 15688, 15689, 16524, 15691, 17533, 18168, 17521, 16457, 15687, 16152) AND (`Item` IN (29434));

--- a/src/Bracket_70_3_1/sql/world/progression_70_3_1_unnerf_t4_loot.sql
+++ b/src/Bracket_70_3_1/sql/world/progression_70_3_1_unnerf_t4_loot.sql
@@ -6,13 +6,13 @@ INSERT INTO `creature_loot_template` (`Entry`, `Item`, `Reference`, `Chance`, `Q
 (18831, 28799, 0, 0, 0, 1, 1, 1, 1, 'High King Maulgar - Belt of Divine Inspiration'),
 (18831, 28800, 0, 0, 0, 1, 1, 1, 1, 'High King Maulgar - Hammer of the Naaru'),
 (18831, 28801, 0, 0, 0, 1, 1, 1, 1, 'High King Maulgar - Maulgar\'s Warhelm'),
-(18831, 34050, 34050, 100, 0, 1, 1, 1, 3, 'High King Maulgar - (ReferenceTable)');
+(18831, 34050, 34050, 100, 0, 1, 1, 1, 2, 'High King Maulgar - (ReferenceTable)');
   
 DELETE FROM `creature_loot_template` WHERE (`Entry` = 19044);
 INSERT INTO `creature_loot_template` (`Entry`, `Item`, `Reference`, `Chance`, `QuestRequired`, `LootMode`, `GroupId`, `MinCount`, `MaxCount`, `Comment`) VALUES
 (19044, 31750, 0, 100, 1, 1, 0, 1, 1, 'Gruul the Dragonkiller - Earthen Signet'),
-(19044, 34051, 34051, 100, 0, 1, 0, 1, 2, 'Gruul the Dragonkiller - (ReferenceTable)'),
-(19044, 190039, 34051, 100, 0, 1, 1, 1, 1, 'Gruul the Dragonkiller - (ReferenceTable)');
+(19044, 34051, 34051, 100, 0, 1, 2, 1, 2, 'Gruul the Dragonkiller - (ReferenceTable)'),
+(19044, 190039, 34051, 100, 0, 1, 1, 1, 2, 'Gruul the Dragonkiller - (ReferenceTable)');
 
 DELETE FROM `creature_loot_template` WHERE (`Entry` = 17257);
 INSERT INTO `creature_loot_template` (`Entry`, `Item`, `Reference`, `Chance`, `QuestRequired`, `LootMode`, `GroupId`, `MinCount`, `MaxCount`, `Comment`) VALUES
@@ -21,4 +21,4 @@ INSERT INTO `creature_loot_template` (`Entry`, `Item`, `Reference`, `Chance`, `Q
 (17257, 34039, 34039, 100, 0, 1, 1, 1, 1, 'Magtheridon - (ReferenceTable)'),
 (17257, 34845, 0, 100, 0, 1, 0, 1, 1, 'Magtheridon - Pit Lord\'s Satchel'),
 (17257, 34846, 0, 100, 0, 1, 0, 1, 1, 'Magtheridon - Black Sack of Gems'),
-(17257, 90039, 34039, 100, 0, 1, 0, 1, 2, 'Magtheridon - (ReferenceTable)');
+(17257, 90039, 34039, 100, 0, 1, 2, 2, 2, 'Magtheridon - (ReferenceTable)');

--- a/src/Bracket_70_3_1/sql/world/progression_70_3_1_unnerf_t4_loot.sql
+++ b/src/Bracket_70_3_1/sql/world/progression_70_3_1_unnerf_t4_loot.sql
@@ -6,19 +6,16 @@ INSERT INTO `creature_loot_template` (`Entry`, `Item`, `Reference`, `Chance`, `Q
 (18831, 28799, 0, 0, 0, 1, 1, 1, 1, 'High King Maulgar - Belt of Divine Inspiration'),
 (18831, 28800, 0, 0, 0, 1, 1, 1, 1, 'High King Maulgar - Hammer of the Naaru'),
 (18831, 28801, 0, 0, 0, 1, 1, 1, 1, 'High King Maulgar - Maulgar\'s Warhelm'),
-(18831, 29434, 0, 100, 0, 1, 0, 2, 2, 'High King Maulgar - Badge of Justice'),
 (18831, 34050, 34050, 100, 0, 1, 1, 1, 3, 'High King Maulgar - (ReferenceTable)');
   
 DELETE FROM `creature_loot_template` WHERE (`Entry` = 19044);
 INSERT INTO `creature_loot_template` (`Entry`, `Item`, `Reference`, `Chance`, `QuestRequired`, `LootMode`, `GroupId`, `MinCount`, `MaxCount`, `Comment`) VALUES
-(19044, 29434, 0, 100, 0, 1, 0, 3, 3, 'Gruul the Dragonkiller - Badge of Justice'),
 (19044, 31750, 0, 100, 1, 1, 0, 1, 1, 'Gruul the Dragonkiller - Earthen Signet'),
 (19044, 34051, 34051, 100, 0, 1, 0, 1, 2, 'Gruul the Dragonkiller - (ReferenceTable)'),
 (19044, 190039, 34051, 100, 0, 1, 1, 1, 1, 'Gruul the Dragonkiller - (ReferenceTable)');
 
 DELETE FROM `creature_loot_template` WHERE (`Entry` = 17257);
 INSERT INTO `creature_loot_template` (`Entry`, `Item`, `Reference`, `Chance`, `QuestRequired`, `LootMode`, `GroupId`, `MinCount`, `MaxCount`, `Comment`) VALUES
-(17257, 29434, 0, 100, 0, 1, 0, 3, 3, 'Magtheridon - Badge of Justice'),
 (17257, 32385, 0, 100, 0, 1, 0, 1, 1, 'Magtheridon - Magtheridon\'s Head'),
 (17257, 32386, 0, 100, 0, 1, 0, 1, 1, 'Magtheridon - Magtheridon\'s Head'),
 (17257, 34039, 34039, 100, 0, 1, 1, 1, 1, 'Magtheridon - (ReferenceTable)'),

--- a/src/Bracket_70_3_1/sql/world/progression_70_3_1_unnerf_t4_loot.sql
+++ b/src/Bracket_70_3_1/sql/world/progression_70_3_1_unnerf_t4_loot.sql
@@ -1,0 +1,27 @@
+DELETE FROM `creature_loot_template` WHERE (`Entry` = 18831);
+INSERT INTO `creature_loot_template` (`Entry`, `Item`, `Reference`, `Chance`, `QuestRequired`, `LootMode`, `GroupId`, `MinCount`, `MaxCount`, `Comment`) VALUES
+(18831, 28795, 0, 0, 0, 1, 1, 1, 1, 'High King Maulgar - Bladespire Warbands'),
+(18831, 28796, 0, 0, 0, 1, 1, 1, 1, 'High King Maulgar - Malefic Mask of the Shadows'),
+(18831, 28797, 0, 0, 0, 1, 1, 1, 1, 'High King Maulgar - Brute Cloak of the Ogre-Magi'),
+(18831, 28799, 0, 0, 0, 1, 1, 1, 1, 'High King Maulgar - Belt of Divine Inspiration'),
+(18831, 28800, 0, 0, 0, 1, 1, 1, 1, 'High King Maulgar - Hammer of the Naaru'),
+(18831, 28801, 0, 0, 0, 1, 1, 1, 1, 'High King Maulgar - Maulgar\'s Warhelm'),
+(18831, 29434, 0, 100, 0, 1, 0, 2, 2, 'High King Maulgar - Badge of Justice'),
+(18831, 34050, 34050, 100, 0, 1, 1, 1, 3, 'High King Maulgar - (ReferenceTable)');
+  
+DELETE FROM `creature_loot_template` WHERE (`Entry` = 19044);
+INSERT INTO `creature_loot_template` (`Entry`, `Item`, `Reference`, `Chance`, `QuestRequired`, `LootMode`, `GroupId`, `MinCount`, `MaxCount`, `Comment`) VALUES
+(19044, 29434, 0, 100, 0, 1, 0, 3, 3, 'Gruul the Dragonkiller - Badge of Justice'),
+(19044, 31750, 0, 100, 1, 1, 0, 1, 1, 'Gruul the Dragonkiller - Earthen Signet'),
+(19044, 34051, 34051, 100, 0, 1, 0, 1, 2, 'Gruul the Dragonkiller - (ReferenceTable)'),
+(19044, 190039, 34051, 100, 0, 1, 1, 1, 1, 'Gruul the Dragonkiller - (ReferenceTable)');
+
+DELETE FROM `creature_loot_template` WHERE (`Entry` = 17257);
+INSERT INTO `creature_loot_template` (`Entry`, `Item`, `Reference`, `Chance`, `QuestRequired`, `LootMode`, `GroupId`, `MinCount`, `MaxCount`, `Comment`) VALUES
+(17257, 29434, 0, 100, 0, 1, 0, 3, 3, 'Magtheridon - Badge of Justice'),
+(17257, 32385, 0, 100, 0, 1, 0, 1, 1, 'Magtheridon - Magtheridon\'s Head'),
+(17257, 32386, 0, 100, 0, 1, 0, 1, 1, 'Magtheridon - Magtheridon\'s Head'),
+(17257, 34039, 34039, 100, 0, 1, 1, 1, 1, 'Magtheridon - (ReferenceTable)'),
+(17257, 34845, 0, 100, 0, 1, 0, 1, 1, 'Magtheridon - Pit Lord\'s Satchel'),
+(17257, 34846, 0, 100, 0, 1, 0, 1, 1, 'Magtheridon - Black Sack of Gems'),
+(17257, 90039, 34039, 100, 0, 1, 0, 1, 2, 'Magtheridon - (ReferenceTable)');


### PR DESCRIPTION
closes https://github.com/chromiecraft/chromiecraft/issues/5930

1 token currently

2 tokens when serpentshrine opens 

down from 3 tokens each all the time