### PR TITLE
change ID of SSC attunement quest to match the quest actually available in game

### DIFF
--- a/src/Bracket_61_64/sql/world/progression_61_64_dungeon_access_requirements_attunements.sql
+++ b/src/Bracket_61_64/sql/world/progression_61_64_dungeon_access_requirements_attunements.sql
@@ -8,7 +8,7 @@ INSERT INTO `dungeon_access_requirements` (`dungeon_access_id`, `requirement_typ
 (54, 2, 27991, 1, (NULL), 'Progression: Auchindoun: Shadow Labyrinth (Normal)'),
 (55, 2, 27991, 1, (NULL), 'Progression: Auchindoun: Shadow Labyrinth (Heroic)'),
 (29, 2, 24490, 0, 'You must have the item The Master\'s Key to enter Karazhan.', 'Progression: Phase 1: Karazhan'),
-(46, 1, 10901, 0, 'You must complete the quest "The Cudgel of Kar\'desh" starting at "Skar\'this the Heretic" before entering the Serpentshrine Cavern.', 'Progression: Phase 2: Serpentshrine Cavern'),
+(46, 1, 13431, 0, 'You must complete the quest "The Cudgel of Kar\'desh" starting at "Skar\'this the Heretic" before entering the Serpentshrine Cavern.', 'Progression: Phase 2: Serpentshrine Cavern'),
 (47, 2, 31704, 0, 'You must have the item The Tempest Key to enter The Eye.', 'Progression: Phase 2: The Eye'),
 (32, 1, 13432, 0, 'You must complete the quest "The Vials of Eternity" before entering the Hyjal Summit.', 'Progression: Phase 3: Battle for Mount Hyjal'),
 (64, 1, 10985, 0, 'You must have the item Medallion of Karabor to enter the Black Temple.', 'Progression: Phase 3: The Black Temple');


### PR DESCRIPTION
![image](https://github.com/azerothcore/mod-progression-system/assets/83884799/38344fe4-94a3-4e68-9f4d-cb5b7e83fb9c)
the bottom one is the one in game right now. the top one is not in game. this is currently preventing access to SSC. old ID is the id of the unavailable one in this picture and the new ID is the other one.


something similar happens for Hyjal. But here we already had the correct new id in place (13432 instead of 10445)
![image](https://github.com/azerothcore/mod-progression-system/assets/83884799/7687e019-cd6c-4458-9872-b31d28858d29)
