### PR TITLE
Add progression stages for Love is in the Air's Bouquets of Red Roses to drop from dungeon bosses.

### DIFF
--- a/src/Bracket_1_19/sql/world/progression_1_19_love_in_air.sql
+++ b/src/Bracket_1_19/sql/world/progression_1_19_love_in_air.sql
@@ -29,6 +29,7 @@ INSERT INTO `creature_loot_template` (`Entry`, `Item`, `Reference`, `Chance`, `Q
 (10901, 22206, 0, 0, 0, 1, 2, 1, 1, 'Love is in the Air - Lorekeeper Polkelt - Bouquet of Red Roses'),
 (11488, 22206, 0, 0, 0, 1, 3, 1, 1, 'Love is in the Air - Illyanna Ravenoak - Bouquet of Red Roses');
 
+DELETE FROM `conditions` WHERE (`SourceTypeOrReferenceId` = 1) AND (`SourceGroup` IN (8929, 10811, 10901, 11488)) AND (`SourceEntry` = 22206) AND (`SourceId` = 0) AND (`ElseGroup` = 0) AND (`ConditionTypeOrReference` = 12) AND (`ConditionTarget` = 0) AND (`ConditionValue1` = 8) AND (`ConditionValue2` = 0) AND (`ConditionValue3` = 0);
 INSERT INTO `conditions` (`SourceTypeOrReferenceId`, `SourceGroup`, `SourceEntry`, `SourceId`, `ElseGroup`, `ConditionTypeOrReference`, `ConditionTarget`, `ConditionValue1`, `ConditionValue2`, `ConditionValue3`, `NegativeCondition`, `ErrorType`, `ErrorTextId`, `ScriptName`, `Comment`) VALUES
 (1, 8929, 22206, 0, 0, 12, 0, 8, 0, 0, 0, 0, 0, '', 'Love is in the Air - Princess Moira Bronzebeard - Bouquet of Red Roses'),
 (1, 10811, 22206, 0, 0, 12, 0, 8, 0, 0, 0, 0, 0, '', 'Love is in the Air - Archivist Galford - Bouquet of Red Roses'),

--- a/src/Bracket_1_19/sql/world/progression_1_19_love_in_air.sql
+++ b/src/Bracket_1_19/sql/world/progression_1_19_love_in_air.sql
@@ -21,6 +21,20 @@ INSERT INTO `item_loot_template` (`Entry`, `Item`, `Reference`, `Chance`, `Quest
 (54537, 50446, 0, 0, 0, 1, 1, 1, 1, NULL),
 (54537, 50471, 0, 0, 0, 1, 1, 1, 1, NULL);
 
+-- Bouquet of Red Roses
+DELETE FROM `creature_loot_template` WHERE (`Entry` IN (8929, 10811, 10901, 11488)) AND (`Item` = 22206);
+INSERT INTO `creature_loot_template` (`Entry`, `Item`, `Reference`, `Chance`, `QuestRequired`, `LootMode`, `GroupId`, `MinCount`, `MaxCount`, `Comment`) VALUES
+(8929, 22206, 0, 0, 0, 1, 2, 1, 1, 'Love is in the Air - Princess Moira Bronzebeard - Bouquet of Red Roses'),
+(10811, 22206, 0, 0, 0, 1, 2, 1, 1, 'Love is in the Air - Archivist Galford - Bouquet of Red Roses'),
+(10901, 22206, 0, 0, 0, 1, 2, 1, 1, 'Love is in the Air - Lorekeeper Polkelt - Bouquet of Red Roses'),
+(11488, 22206, 0, 0, 0, 1, 3, 1, 1, 'Love is in the Air - Illyanna Ravenoak - Bouquet of Red Roses');
+
+INSERT INTO `conditions` (`SourceTypeOrReferenceId`, `SourceGroup`, `SourceEntry`, `SourceId`, `ElseGroup`, `ConditionTypeOrReference`, `ConditionTarget`, `ConditionValue1`, `ConditionValue2`, `ConditionValue3`, `NegativeCondition`, `ErrorType`, `ErrorTextId`, `ScriptName`, `Comment`) VALUES
+(1, 8929, 22206, 0, 0, 12, 0, 8, 0, 0, 0, 0, 0, '', 'Love is in the Air - Princess Moira Bronzebeard - Bouquet of Red Roses'),
+(1, 10811, 22206, 0, 0, 12, 0, 8, 0, 0, 0, 0, 0, '', 'Love is in the Air - Archivist Galford - Bouquet of Red Roses'),
+(1, 10901, 22206, 0, 0, 12, 0, 8, 0, 0, 0, 0, 0, '', 'Love is in the Air - Lorekeeper Polkelt - Bouquet of Red Roses'),
+(1, 11488, 22206, 0, 0, 12, 0, 8, 0, 0, 0, 0, 0, '', 'Love is in the Air - Illyanna Ravenoak - Bouquet of Red Roses');
+
 UPDATE `creature_template` SET `minlevel` = 62, `maxlevel` = 62 WHERE `entry` IN (36565, 36296, 36272, 36568);
 UPDATE `creature_template` SET `minlevel` = 60, `maxlevel` = 60 WHERE `entry` = 36568; -- crazed apothecary
 UPDATE `creature_template` SET `lootid` = 0 WHERE `entry` = 36296;

--- a/src/Bracket_80_1/sql/world/progression_1_19_love_in_air_down.sql
+++ b/src/Bracket_80_1/sql/world/progression_1_19_love_in_air_down.sql
@@ -10,6 +10,10 @@ INSERT INTO `item_loot_template` (`Entry`, `Item`, `Reference`, `Chance`, `Quest
 (54537,49927,0,100,0,1,0,5,10,'Heart-Shaped Box - Love Token'),
 (54537,50250,0,0.1,0,1,0,1,1,'Heart-Shaped Box - Big Love Rocket');
 
+-- Bouquet of Red Roses
+DELETE FROM `creature_loot_template` WHERE (`Entry` IN (8929, 10811, 10901, 11488)) AND (`Item` = 22206);
+DELETE FROM `conditions` WHERE (`SourceTypeOrReferenceId` = 1) AND (`SourceGroup` IN (8929, 10811, 10901, 11488)) AND (`SourceEntry` = 22206) AND (`SourceId` = 0) AND (`ElseGroup` = 0) AND (`ConditionTypeOrReference` = 12) AND (`ConditionTarget` = 0) AND (`ConditionValue1` = 8) AND (`ConditionValue2` = 0) AND (`ConditionValue3` = 0);
+
 UPDATE `creature_template` SET `minlevel` = 82, `maxlevel` = 82 WHERE `entry` IN (36565, 36296, 36272);
 UPDATE `creature_template` SET `minlevel` = 80, `maxlevel` = 80 WHERE `entry` = 36568; -- crazed apothecary
 UPDATE `creature_template` SET `lootid` = 36296 WHERE `entry` = 36296;


### PR DESCRIPTION
Sourced from Wowhead, used existing Northrend dungeon boss loot as reference. Accounts for vanilla content as the drops were not updated for TBC.

Here is the expected loot with this PR:
```
Red Roses:
 -  Vanilla
        Princess Moira Bronzebeard - Blackrock Depths
        Archivist Galford - Stratholme
        Lorekeeper Polkelt - Scholomance
        Illyanna Ravenoak - Dire Maul
 -  WotLK
        Prince Keleseth - Utgarde Keep
        Maiden of Grief - Halls of Stone
        Prince Taldaram - Ahn'kahet: The Old Kingdom

Ebon Roses:
 -  WotLK
        Prince Keleseth - Utgarde Keep
        Maiden of Grief - Halls of Stone
        Prince Taldaram - Ahn'kahet: The Old Kingdom
```