### PR TITLE
feature(Attunements): allow BT attunement quest on SSC release

### DIFF
--- a/src/Bracket_70_3_1/sql/world/progression_61_64_disables_quest_BT_attunement_down.sql
+++ b/src/Bracket_70_3_1/sql/world/progression_61_64_disables_quest_BT_attunement_down.sql
@@ -1,0 +1,2 @@
+-- Enable BT attunement quest chain
+DELETE FROM `disables` WHERE `sourceType`=1 AND `entry` IN (10944);

--- a/src/Bracket_70_4_1/sql/world/progression_61_64_disables_quest_BT_attunement_down.sql
+++ b/src/Bracket_70_4_1/sql/world/progression_61_64_disables_quest_BT_attunement_down.sql
@@ -1,2 +1,0 @@
--- Enable BT attunement quest chain
-DELETE FROM `disables` WHERE `sourceType`=1 AND `entry` IN (10944);


### PR DESCRIPTION
makes sense as the creature that continues the attunement inhabits SSC