### PR TITLE
feature(T5): split attunement requirement for SSC

### DIFF
--- a/src/Bracket_70_3_2/sql/world/progression_61_64_dungeon_access_requirements_attunements_down_2a.sql
+++ b/src/Bracket_70_3_2/sql/world/progression_61_64_dungeon_access_requirements_attunements_down_2a.sql
@@ -1,0 +1,2 @@
+-- Remove attunement requirement for SSC
+DELETE FROM `dungeon_access_requirements` WHERE `comment` LIKE 'Progression:%' AND `dungeon_access_id` IN (33,34,48,49,54,55,29,46);

--- a/src/Bracket_70_4_1/sql/world/progression_61_64_dungeon_access_requirements_attunements_down_2.sql
+++ b/src/Bracket_70_4_1/sql/world/progression_61_64_dungeon_access_requirements_attunements_down_2.sql
@@ -1,2 +1,0 @@
--- Remove attunement requirement for SSC and The Eye
-DELETE FROM `dungeon_access_requirements` WHERE `comment` LIKE 'Progression:%' AND `dungeon_access_id` IN (33,34,48,49,54,55,29,46,47);

--- a/src/Bracket_70_4_1/sql/world/progression_61_64_dungeon_access_requirements_attunements_down_2b.sql
+++ b/src/Bracket_70_4_1/sql/world/progression_61_64_dungeon_access_requirements_attunements_down_2b.sql
@@ -1,0 +1,2 @@
+-- Remove attunement requirement for The Eye
+DELETE FROM `dungeon_access_requirements` WHERE `comment` LIKE 'Progression:%' AND `dungeon_access_id` IN (33,34,48,49,54,55,29,46,47);


### PR DESCRIPTION
SSC no longer needs attunement during the Eye phase

we might want to revert this back at some point tho