### PR TITLE
Add progression stages for Zul'Aman's prisoner loot.

### DIFF
--- a/src/Bracket_70_5/sql/world/progression_70_5_amani_war_bear_loot.sql
+++ b/src/Bracket_70_5/sql/world/progression_70_5_amani_war_bear_loot.sql
@@ -1,0 +1,24 @@
+SET @REFIDTHREE = 35102,
+@REFIDFOUR      = 527000,
+@TANZAR         = 22699,
+@KRAZ           = 22790,
+@ASHLI          = 22797,
+@HARKOR         = 22968;
+
+DELETE FROM `gameobject_loot_template` WHERE (`Entry` IN (@TANZAR, @KRAZ, @ASHLI, @HARKOR)) AND (`Item` = @REFIDFOUR);
+INSERT INTO `gameobject_loot_template` (`Entry`, `Item`, `Reference`, `Chance`, `QuestRequired`, `LootMode`, `GroupId`, `MinCount`, `MaxCount`, `Comment`) VALUES
+(@TANZAR, @REFIDFOUR, @REFIDFOUR, 100, 0, 1, 0, 1, 1, 'Tanzar\'s Trunk - Fourth Hostage Loot'),
+(@KRAZ,   @REFIDFOUR, @REFIDFOUR, 100, 0, 1, 0, 1, 1, 'Kraz\'s Package - Fourth Hostage Loot'),
+(@ASHLI,  @REFIDFOUR, @REFIDFOUR, 100, 0, 1, 0, 1, 1, 'Ashli\'s Bag - Fourth Hostage Loot'),
+(@HARKOR, @REFIDFOUR, @REFIDFOUR, 100, 0, 1, 0, 1, 1, 'Harkor\'s Satchel - Fourth Hostage Loot');
+
+DELETE FROM `reference_loot_template` WHERE `Entry` = @REFIDFOUR;
+INSERT INTO `reference_loot_template` (`Entry`, `Item`, `Reference`, `Chance`, `QuestRequired`, `LootMode`, `GroupId`, `MinCount`, `MaxCount`, `Comment`) VALUES
+(@REFIDFOUR, 33809, 0, 0, 0, 1, 1, 1, 1, 'Zul\'Aman - Fourth Hostage Loot - Amani War Bear');
+
+UPDATE `conditions` SET `ElseGroup` = 0 WHERE (`SourceTypeOrReferenceId` = 10) AND (`SourceGroup` = @REFIDTHREE) AND (`ConditionTypeOrReference` = 13) AND (`ConditionValue2` = 3);
+
+DELETE FROM `conditions` WHERE (`SourceTypeOrReferenceId` = 10) AND (`SourceGroup` = @REFIDFOUR) AND (`ConditionTypeOrReference` = 13) AND (`ConditionValue1` = 8) AND (`ConditionValue2` = 4);
+INSERT INTO `conditions` (`SourceTypeOrReferenceId`, `SourceGroup`, `SourceEntry`, `SourceId`, `ElseGroup`, `ConditionTypeOrReference`, `ConditionTarget`, `ConditionValue1`, `ConditionValue2`, `ConditionValue3`, `NegativeCondition`, `ErrorType`, `ErrorTextId`, `ScriptName`, `Comment`) VALUES
+(10, @REFIDFOUR, 33809, 0, 0, 13, 0, 8, 4, 0, 0, 0, 0, '', 'Yield Amani War Bear if all hostages have been rescued');
+  

--- a/src/Bracket_71_74/sql/world/progression_70_5_amani_war_bear_loot_down.sql
+++ b/src/Bracket_71_74/sql/world/progression_70_5_amani_war_bear_loot_down.sql
@@ -1,0 +1,20 @@
+SET @REFIDTHREE = 35102,
+@REFIDFOUR      = 527000,
+@TANZAR         = 22699,
+@KRAZ           = 22790,
+@ASHLI          = 22797,
+@HARKOR         = 22968;
+
+DELETE FROM `gameobject_loot_template` WHERE (`Entry` IN (@TANZAR, @KRAZ, @ASHLI, @HARKOR)) AND (`Item` = @REFIDFOUR);
+
+DELETE FROM `reference_loot_template` WHERE (`Entry` = @REFIDFOUR) AND (`Item` = 33809);
+
+UPDATE `conditions` SET `ElseGroup` = 1 WHERE (`SourceTypeOrReferenceId` = 10) AND (`SourceGroup` = @REFIDTHREE) AND (`ConditionTypeOrReference` = 13) AND (`ConditionValue2` = 3);
+
+DELETE FROM `conditions` WHERE (`SourceTypeOrReferenceId` = 10) AND (`SourceGroup` IN (@REFIDTHREE, @REFIDFOUR)) AND (`ConditionTypeOrReference` = 13) AND (`ConditionValue1` = 8) AND (`ConditionValue2` = 4);
+INSERT INTO `conditions` (`SourceTypeOrReferenceId`, `SourceGroup`, `SourceEntry`, `SourceId`, `ElseGroup`, `ConditionTypeOrReference`, `ConditionTarget`, `ConditionValue1`, `ConditionValue2`, `ConditionValue3`, `NegativeCondition`, `ErrorType`, `ErrorTextId`, `ScriptName`, `Comment`) VALUES
+(10, @REFIDTHREE, 33496, 0, 2, 13, 0, 8, 4, 0, 0, 0, 0, '', 'Yield third hostage loot if all hostages have been rescued'),
+(10, @REFIDTHREE, 33497, 0, 2, 13, 0, 8, 4, 0, 0, 0, 0, '', 'Yield third hostage loot if all hostages have been rescued'),
+(10, @REFIDTHREE, 33498, 0, 2, 13, 0, 8, 4, 0, 0, 0, 0, '', 'Yield third hostage loot if all hostages have been rescued'),
+(10, @REFIDTHREE, 33499, 0, 2, 13, 0, 8, 4, 0, 0, 0, 0, '', 'Yield third hostage loot if all hostages have been rescued'),
+(10, @REFIDTHREE, 33500, 0, 2, 13, 0, 8, 4, 0, 0, 0, 0, '', 'Yield third hostage loot if all hostages have been rescued');


### PR DESCRIPTION
Adds Amani War Bear to the various prisoner loot game objects. Gets added with Zul'Aman release bracket, removed with first Northrend content bracket (71-74).

Not to be merged prior to [AC PR](https://github.com/azerothcore/azerothcore-wotlk/pull/18869).