### PR TITLE
fix: instance buffer overflow

### DIFF
--- a/src/Bracket_50_59_2/scripts/BlackrockSpire/instance_blackrock_spire.cpp
+++ b/src/Bracket_50_59_2/scripts/BlackrockSpire/instance_blackrock_spire.cpp
@@ -67,7 +67,8 @@ enum Texts
 
 MinionData const minionData[] =
 {
-    { NPC_CHROMATIC_ELITE_GUARD, DATA_GENERAL_DRAKKISATH }
+    { NPC_CHROMATIC_ELITE_GUARD, DATA_GENERAL_DRAKKISATH },
+    { 0, 0 } // END
 };
 
 DoorData const doorData[] =

--- a/src/Bracket_60_2_1/scripts/OnyxiasLair/instance_onyxias_lair.cpp
+++ b/src/Bracket_60_2_1/scripts/OnyxiasLair/instance_onyxias_lair.cpp
@@ -22,7 +22,8 @@
 
 ObjectData const creatureData[] =
 {
-    { NPC_ONYXIA, DATA_ONYXIA }
+    { NPC_ONYXIA, DATA_ONYXIA },
+    { 0, 0 } // END
 };
 
 class instance_onyxias_lair_60_2 : public InstanceMapScript


### PR DESCRIPTION
MinionData const minionData[]  is missing a {0, 0} entry to stop reading 

See `void InstanceScript::LoadMinionData(const MinionData* data)`
- https://github.com/azerothcore/azerothcore-wotlk/blob/fe206c71385aac5e12e13f436baa9273885ca3f2/src/server/game/Instances/InstanceScript.cpp#L166

same for creatureData[]