### PR TITLE
Add new progression bracket '70_6_3'

### DIFF
--- a/src/ProgressionSystem.h
+++ b/src/ProgressionSystem.h
@@ -39,6 +39,7 @@ std::array<std::string, PROGRESSION_BRACKET_MAX> const ProgressionBracketsNames 
     "70_5",
     "70_6_1",
     "70_6_2",
+    "70_6_3",
     "71_74",
     "75_79",
     "80_1",


### PR DESCRIPTION
Introduced a new entry '70_6_3' to the ProgressionBracketsNames array to support an additional progression bracket.