### PR TITLE
chore: remove unused variables to silence compiler warnings

### DIFF
--- a/src/Bracket_60_1_2/scripts/MoltenCore/instance_molten_core.cpp
+++ b/src/Bracket_60_1_2/scripts/MoltenCore/instance_molten_core.cpp
@@ -501,7 +501,7 @@ public:
             instance->DoAction(ACTION_CHECK_RUNES);
         }
 
-        if (uint32 cooldown = player->GetSpellCooldownDelay(SPELL_AQUAL_QUINTESSENCE))
+        if (player->GetSpellCooldownDelay(SPELL_AQUAL_QUINTESSENCE))
         {
             int32 cooldownredux = sConfigMgr->GetOption<int>("ProgressionSystem.60.MoltenCore.AqualEssenceCooldownReduction", 0);
             player->ModifySpellCooldown(SPELL_AQUAL_QUINTESSENCE, -(cooldownredux * MINUTE * IN_MILLISECONDS));

--- a/src/Bracket_60_2_1/scripts/TheMasquerade/quest_jail_break.cpp
+++ b/src/Bracket_60_2_1/scripts/TheMasquerade/quest_jail_break.cpp
@@ -255,7 +255,7 @@ public:
 
                 _scheduler.Schedule(5s, [this](TaskContext task)
                     {
-                        if (Creature* shill = me->FindNearestCreature(NPC_SHILL_DINGER, 50.0f))
+                        if (me->FindNearestCreature(NPC_SHILL_DINGER, 50.0f))
                         {
                             task.Repeat();
                         }
@@ -279,7 +279,7 @@ public:
 
                 _scheduler.Schedule(5s, [this](TaskContext task)
                     {
-                        if (Creature* prisioner = me->FindNearestCreature(NPC_CREST_KILLER, 50.0f))
+                        if (me->FindNearestCreature(NPC_CREST_KILLER, 50.0f))
                         {
                             task.Repeat();
                         }


### PR DESCRIPTION
Three `-Wunused-but-set-variable` warnings during the build, all cases where we only care whether the lookup found something:

```
src/Bracket_60_1_2/scripts/MoltenCore/instance_molten_core.cpp:504:20: warning: variable 'cooldown' set but not used
src/Bracket_60_2_1/scripts/TheMasquerade/quest_jail_break.cpp:258:39: warning: variable 'shill' set but not used
src/Bracket_60_2_1/scripts/TheMasquerade/quest_jail_break.cpp:282:39: warning: variable 'prisioner' set but not used
```

Dropped the bindings, the conditions stay the same.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved internal handling of Aqual Quintessence cooldown checks.
  * Removed unused escort-related variables without changing gameplay behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->