### PR TITLE
fix(DB): Restore heroic Oculus item level requirement to 180

### DIFF
--- a/src/Bracket_80_1_1/sql/world/progression_80_1_dungeon_access_template.sql
+++ b/src/Bracket_80_1_1/sql/world/progression_80_1_dungeon_access_template.sql
@@ -1,2 +1,3 @@
-UPDATE `dungeon_access_template` SET `min_avg_item_level` = 150 WHERE `id` IN (68, 70, 72, 74, 79, 81, 83, 87, 91, 93, 99) AND `difficulty` = 1;
--- AN intentionally left at 180 for now
+UPDATE `dungeon_access_template` SET `min_avg_item_level` = 150 WHERE `id` IN (68, 70, 72, 79, 81, 83, 87, 91, 93, 99) AND `difficulty` = 1;
+-- AN and Oculus intentionally left at 180 for now
+UPDATE `dungeon_access_template` SET `min_avg_item_level` = 180 WHERE `id` = 74 AND `difficulty` = 1;


### PR DESCRIPTION
Heroic Oculus (`dungeon_access_template` id 74) was part of the batch that lowers heroic dungeon access requirements to average item level 150 at the first level 80 bracket (80_1_1). This restores the base requirement of 180, same as Azjol-Nerub, which was already deliberately kept at 180.

Instead of only removing id 74 from the 150 list, the file also sets it back to 180 explicitly. The updater re-applies changed SQL files, so realms that already ran the old version of this bracket get corrected too.

Nothing in the history records why Oculus was included in the 150 batch to begin with, so flagging in case that was intentional.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated dungeon access requirements to keep selected instances at a minimum item level of 150.
  * Preserved the Oculus requirement at item level 180.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->