### PR TITLE
fix(DB): Ulduar drops Valor/Conquest instead of Heroism in 80_2

### DIFF
--- a/src/Bracket_80_2/sql/world/progression_80_2_ulduar_emblems.sql
+++ b/src/Bracket_80_2/sql/world/progression_80_2_ulduar_emblems.sql
@@ -1,0 +1,52 @@
+-- Ulduar at patch 3.1: 10-man drops Emblem of Valor, 25-man drops Emblem of
+-- Conquest. The rows hold Heroism after the Bracket_80_1_2 blanket conversion,
+-- or Triumph on a stock 3.3.5 database, so both are matched.
+
+-- 10-man bosses: Valor
+-- Brundir, Steelbreaker, Molgeim, Ignis, Razorscale, Vezax, Yogg-Saron, XT-002, Auriaya
+UPDATE `creature_loot_template`
+SET `Item` = 40753, `Comment` = REPLACE(`Comment`, 'Emblem of Triumph', 'Emblem of Valor')
+WHERE `Entry` IN (32857, 32867, 32927, 33118, 33186, 33271, 33288, 33293, 33515)
+AND `Item` IN (40752, 47241);
+
+-- 25-man bosses: Conquest
+UPDATE `creature_loot_template`
+SET `Item` = 45624, `Comment` = REPLACE(`Comment`, 'Emblem of Triumph', 'Emblem of Conquest')
+WHERE `Entry` IN (33694, 33693, 33692, 33190, 33724, 33449, 33955, 33885, 34175)
+AND `Item` IN (40752, 47241);
+
+-- 10-man caches: Valor
+-- Kologarn 27061, Hodir 27068, Thorim 27073/27074, Mimiron 27085/27086,
+-- Algalon 27030, Freya's Gift 26959/26961/27078/27080
+UPDATE `gameobject_loot_template`
+SET `Item` = 40753, `Comment` = REPLACE(`Comment`, 'Emblem of Triumph', 'Emblem of Valor')
+WHERE `Entry` IN (27061, 27068, 27073, 27074, 27085, 27086, 27030, 26959, 26961, 27078, 27080)
+AND `Item` IN (40752, 47241);
+
+-- 25-man caches: Conquest
+-- Kologarn 26929, Hodir 26946, Thorim 26955/26956, Mimiron 26963/26967,
+-- Algalon 26974, Freya's Gift 26960/26962/27079/27081
+UPDATE `gameobject_loot_template`
+SET `Item` = 45624, `Comment` = REPLACE(`Comment`, 'Emblem of Triumph', 'Emblem of Conquest')
+WHERE `Entry` IN (26929, 26946, 26955, 26956, 26963, 26967, 26974, 26960, 26962, 27079, 27081)
+AND `Item` IN (40752, 47241);
+
+-- Flame Leviathan, Yogg-Saron (keeper hard modes) and Freya's Gift (elder hard
+-- modes) take their emblems from reference 34349, which is shared with
+-- Sartharion 25 and follows the Obsidian Sanctum brackets. Give Ulduar its own
+-- per-difficulty references so the two raids can be tuned independently.
+SET @REF_ULDUAR_10 = 80200,
+@REF_ULDUAR_25 = 80201;
+
+DELETE FROM `reference_loot_template` WHERE `Entry` IN (@REF_ULDUAR_10, @REF_ULDUAR_25);
+INSERT INTO `reference_loot_template` (`Entry`, `Item`, `Reference`, `Chance`, `QuestRequired`, `LootMode`, `GroupId`, `MinCount`, `MaxCount`, `Comment`) VALUES
+(@REF_ULDUAR_10, 40753, 0, 100, 0, 1, 0, 1, 1, 'Ulduar 10 - Emblem of Valor'),
+(@REF_ULDUAR_25, 45624, 0, 100, 0, 1, 0, 1, 1, 'Ulduar 25 - Emblem of Conquest');
+
+-- Flame Leviathan 33113 / 34003, Yogg-Saron 33288 / 33955
+UPDATE `creature_loot_template` SET `Reference` = @REF_ULDUAR_10 WHERE `Entry` IN (33113, 33288) AND `Reference` = 34349;
+UPDATE `creature_loot_template` SET `Reference` = @REF_ULDUAR_25 WHERE `Entry` IN (34003, 33955) AND `Reference` = 34349;
+
+-- Freya's Gift with elders alive
+UPDATE `gameobject_loot_template` SET `Reference` = @REF_ULDUAR_10 WHERE `Entry` IN (26959, 27078, 27080) AND `Reference` = 34349;
+UPDATE `gameobject_loot_template` SET `Reference` = @REF_ULDUAR_25 WHERE `Entry` IN (26960, 27081) AND `Reference` = 34349;


### PR DESCRIPTION
## What and why

In the Ulduar bracket (80_2) every Ulduar boss and cache drops Emblem of Heroism on both raid sizes. The stock 3.3.5 rows hold Emblem of Triumph, the 80_1_2 blanket conversion turns all Triumph into Heroism, and nothing afterwards touches Ulduar. At patch 3.1 Ulduar 10 dropped Emblem of Valor and Ulduar 25 dropped Emblem of Conquest. This adds one SQL file to Bracket_80_2 that sets exactly that. Emblem counts per kill are unchanged, only the item swaps.

## Decisions worth knowing

- Flame Leviathan, Yogg-Saron's keeper hard modes and Freya's Gift with elders alive get their emblems through reference table 34349, which Sartharion 25 also uses and which the Obsidian Sanctum files change per bracket. Ulduar now gets its own references (80200 Valor for 10-man, 80201 Conquest for 25-man) and the Ulduar rows are repointed. Sartharion 25 stays on 34349 untouched.
- The reference rows were kept as references instead of being flattened into direct item rows because Yogg-Saron's loot modes stack (mode 1 plus 2 plus 8 with three or fewer keepers), so one direct row per emblem could not reproduce the per-mode counts.
- The WHERE clauses match both Heroism (40752) and Triumph (47241) so the file works after 80_1_2 has run and on a stock database.
- The updater orders files by name across all bracket directories, so this file runs after `progression_80_1_2_emblems.sql` and after the Obsidian Sanctum down file that lives in the same directory.

## Review guide

`src/Bracket_80_2/sql/world/progression_80_2_ulduar_emblems.sql` is the whole change. Judgment is needed on the 10 vs 25 split of the Freya's Gift chests: the gameobject ids alternate by difficulty rather than following the loot id range like the other caches. The split was taken from the loot contents (10-man chests reference the gloves token table 12026 and ilvl 219 gear, 25-man the legplates token table 12027 and ilvl 226 or 239 gear). Everything else is a plain item swap on the boss and cache rows listed in the file comments.

## Known gaps

- Nothing later moves Ulduar to Conquest for both sizes at the ToC bracket (3.2) or to Triumph at the ICC bracket (3.3). That is a small follow-up in Bracket_80_3 and Bracket_80_4_1 updating the two new references plus the direct rows.
- Tested by running the file against a live acore_world inside a rolled-back transaction: every statement hit the expected row count (9 and 9 boss rows, 11 and 11 cache rows, 5 and 5 creature reference rows, 3 and 3 chest reference rows). Not yet tested in-game.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Updated Ulduar loot rewards for the 80-2 bracket:
    - 10-player encounters now award Emblems of Valor.
    - 25-player encounters now award Emblems of Conquest.
  - Added separate loot references for each difficulty, enabling independent reward tuning for Ulduar encounters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->