### PR TITLE
fix(DB): Restore Coren Direbrew to 80 and swap keg Frost for Valor in 80_1

### DIFF
--- a/src/Bracket_80_1_1/sql/world/progression_1_19_brewfest_down.sql
+++ b/src/Bracket_80_1_1/sql/world/progression_1_19_brewfest_down.sql
@@ -1,12 +1,3 @@
-UPDATE `creature_template` SET `minlevel` = 80, `maxlevel` = 80 WHERE `entry` IN (23872, 23795, 26776, 26764, 26822);
-UPDATE `creature_template` SET `lootid` = 23872 WHERE `entry` = 23872;
-
-DELETE FROM `item_loot_template` WHERE `Entry` = 54535 AND `Item` IN (48663, 49120, 49426);
-INSERT INTO `item_loot_template` (`Entry`, `Item`, `Reference`, `Chance`, `QuestRequired`, `LootMode`, `GroupId`, `MinCount`, `MaxCount`, `Comment`) VALUES
-(54535,48663,0,8,0,1,0,1,1,'Keg-Shaped Treasure Chest - Tankard O\' Terror'),
-(54535,49120,0,8,0,1,0,1,1,'Keg-Shaped Treasure Chest - Direbrew\'s Bloody Shanker'),
-(54535,49426,0,100,0,1,1,2,2,'Keg-Shaped Treasure Chest - Emblem of Frost');
-
 UPDATE `creature_template` SET `ScriptName` = '' WHERE `entry` IN (40437, 40441);
 
 DELETE FROM `creature` WHERE `id` IN (40437, 40441) AND `guid` IN (3200500, 3200501);

--- a/src/Bracket_80_1_1/sql/world/progression_80_1_brewfest.sql
+++ b/src/Bracket_80_1_1/sql/world/progression_80_1_brewfest.sql
@@ -1,0 +1,15 @@
+-- Coren Direbrew and his helpers back to level 80 with the stock loot table.
+-- This lives in an 80_1-prefixed file because the updater applies files in
+-- filename order and the level-70 rows from Bracket_70_1_1 / Bracket_70_4_1
+-- must be overridden after them.
+UPDATE `creature_template` SET `minlevel` = 80, `maxlevel` = 80 WHERE `entry` IN (23872, 23795, 26776, 26764, 26822);
+UPDATE `creature_template` SET `lootid` = 23872 WHERE `entry` = 23872;
+
+-- Keg-Shaped Treasure Chest (54535): hand out the phase-appropriate Emblem of
+-- Valor (40753) instead of the ICC-era Emblem of Frost (49426), matching the
+-- heroic daily and the Ahune satchel.
+DELETE FROM `item_loot_template` WHERE `Entry` = 54535 AND `Item` IN (48663, 49120, 49426, 40753);
+INSERT INTO `item_loot_template` (`Entry`, `Item`, `Reference`, `Chance`, `QuestRequired`, `LootMode`, `GroupId`, `MinCount`, `MaxCount`, `Comment`) VALUES
+(54535,48663,0,8,0,1,0,1,1,'Keg-Shaped Treasure Chest - Tankard O\' Terror'),
+(54535,49120,0,8,0,1,0,1,1,'Keg-Shaped Treasure Chest - Direbrew\'s Bloody Shanker'),
+(54535,40753,0,100,0,1,1,2,2,'Keg-Shaped Treasure Chest - Emblem of Valor');


### PR DESCRIPTION
## What and why

In every WotLK bracket Coren Direbrew and his helpers stayed at level 70 with the ilvl-110 TBC trinket table, and the Brewfest RDF keg handed out two Emblems of Frost. The 80_1_1 revert existed but never stuck: the core updater applies SQL files in filename order, so `progression_1_19_brewfest_down.sql` ran right after the 1_19 file and the 70_1_1 (level 70) and 70_4_1 (lootid 238720) files overrode it. The `updates` table timestamps show this on any DB with the 80 brackets enabled.

## Decisions worth knowing

- Split instead of rename: the down file keeps only the 1_19-specific reverts (dungeonmaster script names and spawns). The level, lootid and keg rows moved into the new `progression_80_1_brewfest.sql`. The 80_1 prefix sorts after every 70_x file and keeps the README rule that a file's prefix names the bracket whose content it applies or reverts.
- Emblem of Valor x2 replaces Emblem of Frost x2 in the keg. In this phase the heroic RDF daily rewards Valor (`progression_80_1_rdf_quests.sql`) and the Ahune satchel gives Valor x2 (`progression_80_1_world_event_Ahune_satchel.sql`), so the keg now matches both.
- The keg DELETE lists both Frost and Valor so an already polluted DB is cleaned and re-application is safe. Both files have new hashes, so the updater reapplies them at next startup.

## Review guide

- `src/Bracket_80_1_1/sql/world/progression_80_1_brewfest.sql`: the substantive change. Check the level and lootid updates and the keg rows.
- `src/Bracket_80_1_1/sql/world/progression_1_19_brewfest_down.sql`: mechanical, rows removed only.

## Testing

Applied both files in updater order to a local world DB with brackets up to 80_3 enabled, then re-ran the 80_1 file to confirm idempotency. Result: all five Brewfest NPCs at 80, Coren lootid 23872 (stock ilvl-200 trinkets via reference 34284), keg with Valor x2 at 100%, both weapons at 8%, mounts and remote untouched. Not tested in game.

## Known gaps

- Tankard O' Terror (48663, ilvl 226) stays in the keg in the first WotLK phase. The Ahune file withholds its ilvl-232 scythe until 80_3, and the same could be done here.
- Headless Horseman has the same ordering bug: `progression_1_19_hallows_end_down.sql` restores lootid 23682 and 70_4_1 overwrites it with 236820. The Loot-Filled Pumpkin and Heart-Shaped Box also still give Emblem of Frost. Out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
