### PR TITLE
fix: Use core MAP_ULDUAR instead of redefining it

### DIFF
--- a/src/Bracket_80_2/scripts/Ulduar/ulduar_hard_mode_emblems.cpp
+++ b/src/Bracket_80_2/scripts/Ulduar/ulduar_hard_mode_emblems.cpp
@@ -2,6 +2,7 @@
  * Copyright (C) 2016+ AzerothCore <www.azerothcore.org>, released under GNU AGPL v3 license: https://github.com/azerothcore/azerothcore-wotlk/blob/master/LICENSE-AGPL3
  */
 
+#include "AreaDefines.h"
 #include "LootMgr.h"
 #include "Player.h"
 #include "ScriptMgr.h"
@@ -9,7 +10,6 @@
 
 enum UlduarEmblems
 {
-    MAP_ULDUAR              = 603,
     ITEM_EMBLEM_OF_VALOR    = 40753,
     ITEM_EMBLEM_OF_CONQUEST = 45624,
     LOOT_MODE_HARD_MODES    = LOOT_MODE_HARD_MODE_1 | LOOT_MODE_HARD_MODE_2 | LOOT_MODE_HARD_MODE_3 | LOOT_MODE_HARD_MODE_4


### PR DESCRIPTION
The core now defines `MAP_ULDUAR` in `AreaDefines.h`, so the local enumerator in `ulduar_hard_mode_emblems.cpp` breaks the build:

```
fatal error: redefinition of enumerator 'MAP_ULDUAR'
```

Dropped it from the module enum and included `AreaDefines.h`, matching how `hallows_end.cpp` already gets its map ids.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated Ulduar hard-mode emblem handling to use the shared map identifier, improving consistency without changing player-visible behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->