### PR TITLE
fix(DB): Keep Loot-Filled Pumpkin emblem swap replay-safe

### DIFF
--- a/src/Bracket_80_1_1/sql/world/progression_1_19_hallows_end_down.sql
+++ b/src/Bracket_80_1_1/sql/world/progression_1_19_hallows_end_down.sql
@@ -1,7 +1,7 @@
 SET @QUESTID = 50000;
 DELETE FROM `quest_template` WHERE `ID` = @QUESTID;
 
-DELETE FROM `item_loot_template` WHERE `entry` = 54516 AND `item` IN (49426, 49128, 49126);
+DELETE FROM `item_loot_template` WHERE `entry` = 54516 AND `item` IN (49426, 40753, 49128, 49126);
 INSERT INTO `item_loot_template` (`Entry`, `Item`, `Reference`, `Chance`, `QuestRequired`, `LootMode`, `GroupId`, `MinCount`, `MaxCount`, `Comment`) VALUES
 (54516,49126,0,2,0,1,0,1,1,'Loot-Filled Pumpkin - The Horseman\'s Horrific Helm'),
 (54516,49128,0,2,0,1,0,1,1,'Loot-Filled Pumpkin - The Horseman\'s Baleful Blade'),


### PR DESCRIPTION
## Problem

On a realm with `ProgressionSystem.ReapplyUpdates = 1`, Ulduar is disabled again after every restart, along with Onyxia's Lair, Trial of the Crusader and Trial of the Champion.

The cause is a duplicate-key error in the Hallow's End loot swap added in #492:

- `progression_1_19_hallows_end_down.sql` deletes items `49426, 49128, 49126` from the Loot-Filled Pumpkin (54516) and re-inserts the Emblem of Frost row.
- `progression_80_1_hallows_end.sql` then runs `UPDATE item_loot_template SET Item = 40753 WHERE Entry = 54516 AND Item = 49426`.

The first replay works. On the next one, the converted `40753` row is still there because the down file does not clear it, so the UPDATE collides with the primary key `(Entry, Item)`:

```
ERROR 1062 (23000): Duplicate entry '54516-40753' for key 'item_loot_template.PRIMARY'
```

The updater treats a failed file as fatal and stops, so every file sorting after `progression_80_1_hallows_end.sql` is skipped. That includes `progression_80_2_disables.sql` and `progression_80_3_disables.sql`, which are the only files that lift the map disables for those instances. `progression_0_disables.sql` sorts early and runs fine, so it re-inserts the Ulduar disable on every restart with nothing left to remove it.

Observed on an affected world DB: 174 `progression_*` rows in `updates`, ending at `progression_80_1_epic_gems_down.sql`, with the next 23 files missing starting exactly at `progression_80_1_hallows_end.sql`, and both `40753` and `49426` present on entry 54516.

The Heart-Shaped Box swap in `progression_80_1_love_in_air.sql` is not affected: its down file deletes the whole entry rather than a list of items, so the converted row is cleared first.

## Fix

Add `40753` to the DELETE in `progression_1_19_hallows_end_down.sql` so the slot is free when the swap runs again.

## Tests

Replayed every enabled bracket's SQL in filename order against a world DB inside a transaction:

- Before the fix: one error, the duplicate key above.
- After the fix, three consecutive passes: no errors, entries 54516 and 54537 both end with Emblem of Valor only, and `disables` ends with no row for map 603.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Updated item loot availability by removing item 40753 from the specified Halloween event loot entry.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->